### PR TITLE
Fix Bug 1537 - Improve the NAEFS scripts to use cpfs

### DIFF
--- a/scripts/exnaefs_cmcensbc_prep.sh
+++ b/scripts/exnaefs_cmcensbc_prep.sh
@@ -110,7 +110,7 @@ if [ "$SENDCOM" = "YES" ]; then
   for nfhrs in $hourlist; do
     for mem in $memberlist; do
       PGBO=cmc_ge${mem}.t${cyc}z.pgrb2a.0p50_anf${nfhrs} 
-      mv $DATA/group.$nfhrs/$PGBO $COMOUTAN_GB2/
+       cpfs $DATA/group.$nfhrs/$PGBO $COMOUTAN_GB2/
     done
   done
 fi
@@ -149,7 +149,7 @@ if [ "$SENDCOM" = "YES" ]; then
   for nfhrs in $hourlist; do
     for mem in $memberlist; do
       PGBO=cmc_ge${mem}.t${cyc}z.pgrb2a.0p50_wtf${nfhrs} 
-      mv $DATA/group.$nfhrs/$PGBO $COMOUTWT_GB2/
+       cpfs $DATA/group.$nfhrs/$PGBO $COMOUTWT_GB2/
     done
   done
 fi

--- a/scripts/exnaefs_dvrtma_prob_avgspr_ak.sh
+++ b/scripts/exnaefs_dvrtma_prob_avgspr_ak.sh
@@ -81,7 +81,7 @@ if [ "$SENDCOM" = "YES" ]; then
         if [ -s poe_move.${nfhrs}.${nens} ]; then rm poe_move.${nfhrs}.${nens}; fi
         file_in=naefs_${nens}.t${cyc}z.ndgd3p0_alaskaf${nfhrs}.grib2
         file_out=naefs.t${cyc}z.${nens}.f${nfhrs}.alaska_3p0.grib2
-        echo "mv $file_in $COMOUT_GB2/$file_out" >>poe_move.${nfhrs}.${nens}
+        echo " cpfs $file_in $COMOUT_GB2/$file_out" >>poe_move.${nfhrs}.${nens}
       done 
     done
   fi
@@ -92,7 +92,7 @@ if [ "$SENDCOM" = "YES" ]; then
         if [ -s poe_move.${nfhrs}.${nens} ]; then rm poe_move.${nfhrs}.${nens}; fi
         file_in=${nens}.t${cyc}z.ndgd3p0_alaskaf${nfhrs}.grib2
         file_out=gefs.t${cyc}z.${nens}.f${nfhrs}.alaska_3p0.grib2
-        echo "mv $file_in $COMOUT_GB2/$file_out" >>poe_move.${nfhrs}.${nens}
+        echo " cpfs $file_in $COMOUT_GB2/$file_out" >>poe_move.${nfhrs}.${nens}
       done 
     done
   fi

--- a/scripts/exnaefs_dvrtma_prob_avgspr_conus.sh
+++ b/scripts/exnaefs_dvrtma_prob_avgspr_conus.sh
@@ -81,7 +81,7 @@ if [ "$SENDCOM" = "YES" ]; then
         if [ -s poe_move.${nfhrs}.${nens} ]; then rm poe_move.${nfhrs}.${nens}; fi
         file_in=naefs_${nens}.t${cyc}z.ndgd2p5_conusf${nfhrs}.grib2_ext
         file_out=naefs.t${cyc}z.${nens}.f${nfhrs}.conus_ext_2p5.grib2
-        echo "mv $file_in $COMOUT_GB2/$file_out" >>poe_move.${nfhrs}.${nens}
+        echo " cpfs $file_in $COMOUT_GB2/$file_out" >>poe_move.${nfhrs}.${nens}
       done 
     done
   fi
@@ -92,7 +92,7 @@ if [ "$SENDCOM" = "YES" ]; then
         if [ -s poe_move.${nfhrs}.${nens} ]; then rm poe_move.${nfhrs}.${nens}; fi
         file_in=${nens}.t${cyc}z.ndgd2p5_conusf${nfhrs}.grib2_ext
         file_out=gefs.t${cyc}z.${nens}.f${nfhrs}.conus_ext_2p5.grib2
-        echo "mv $file_in $COMOUT_GB2/$file_out" >>poe_move.${nfhrs}.${nens}
+        echo " cpfs $file_in $COMOUT_GB2/$file_out" >>poe_move.${nfhrs}.${nens}
       done 
     done
   fi

--- a/scripts/exnaefs_fnmoc_ens_debias.sh
+++ b/scripts/exnaefs_fnmoc_ens_debias.sh
@@ -93,11 +93,11 @@ do
         if [ "$SENDCOM" = "YES" ]; then
 
           if [ -s fnmoc_ge${nens}.t${cyc}z.pgrb2a.0p50_anf$nfhrs ]; then
-            mv fnmoc_ge${nens}.t${cyc}z.pgrb2a.0p50_anf$nfhrs $COMOUTAN/
+             cpfs fnmoc_ge${nens}.t${cyc}z.pgrb2a.0p50_anf$nfhrs $COMOUTAN/
           fi
 
           if [ -s fnmoc_ge${nens}.t${cyc}z.pgrb2a.0p50_wtf$nfhrs ]; then
-            mv fnmoc_ge${nens}.t${cyc}z.pgrb2a.0p50_wtf$nfhrs $COMOUTWT/
+             cpfs fnmoc_ge${nens}.t${cyc}z.pgrb2a.0p50_wtf$nfhrs $COMOUTWT/
           fi
         fi
 

--- a/scripts/exnaefs_gefs_anfefi_acpr.sh
+++ b/scripts/exnaefs_gefs_anfefi_acpr.sh
@@ -55,12 +55,12 @@ grid="0 6 0 0 0 0 0 0 720 361 0 0 90000000 0 48 -90000000 359500000 500000 50000
     if [ "$SENDCOM" = "YES" ]; then
        outfile=geprcp.t${cyc}z.pgrb2a.0p50.anvf$nfhrs
        if [ -s $outfile ]; then
-          mv $outfile $COMOUTANFEFI_p5/
+           cpfs $outfile $COMOUTANFEFI_p5/
           $DBNROOT/bin/dbn_alert MODEL NAEFS_GEFS_PCP_BC_GB2 $job $COMOUTANFEFI_p5/${outfile}
        fi
        outfile=geprcp.t${cyc}z.pgrb2a.0p50.efif$nfhrs
        if [ -s $outfile ]; then
-          mv $outfile $COMOUTANFEFI_p5/
+           cpfs $outfile $COMOUTANFEFI_p5/
           $DBNROOT/bin/dbn_alert MODEL NAEFS_GEFS_PCP_BC_GB2 $job $COMOUTANFEFI_p5/${outfile}
        fi
     fi

--- a/scripts/exnaefs_gefs_bias.sh
+++ b/scripts/exnaefs_gefs_bias.sh
@@ -114,12 +114,12 @@ if [ "$SENDCOM" = "YES" ]; then
 
     file=$DATA/dir_decay/glbanl.t${cyc}z.pgrb2a.0p50_mdf000
     if [ -s $file ]; then
-      mv $file $COMOUT_M1/
+       cpfs $file $COMOUT_M1/
     fi
 
     file=$DATA/dir_decay/ncepcmc_glbanl.t${cyc}z.pgrb2a.0p50_mdf000
     if [ -s $file ]; then
-      mv $file $COMOUT_M2/
+       cpfs $file $COMOUT_M2/
     fi
 
   fi
@@ -149,7 +149,7 @@ if [ "$SENDCOM" = "YES" ]; then
   for nfhrs in $hourlist; do
     file=$DATA/dir_combine/geavg.t${cyc}z.pgrb2a.0p50_mecomf${nfhrs}
     if [ -s $file ]; then
-      mv $file $COMOUT/
+       cpfs $file $COMOUT/
     fi
   done
 fi

--- a/scripts/exnaefs_gefs_conus_ndgd_enscqpf.sh
+++ b/scripts/exnaefs_gefs_conus_ndgd_enscqpf.sh
@@ -120,7 +120,7 @@ $USHndgd/conus_ndgd_enscqpf.sh $iacc
       echo "*********** Warning!!! Warning!!! ************"
       echo "**** There is empty file for $outfile_gb2 ********"
     else
-        mv ${infile_gb2} $OUTPATH/${outfile_gb2}
+         cpfs ${infile_gb2} $OUTPATH/${outfile_gb2}
         if [ "$SENDDBN" = "YES" ]; then
            $DBNROOT/bin/dbn_alert MODEL NAEFS_GEFS_PCP_BC_GB2 $job $OUTPATH/${outfile_gb2}
         fi
@@ -131,7 +131,7 @@ $USHndgd/conus_ndgd_enscqpf.sh $iacc
       echo "*********** Warning!!! Warning!!! ************"
       echo "**** There is empty file for $outfile_gb2 ********"
     else
-        mv ${infile_gb2} $OUTPATH/$outfile_gb2 
+         cpfs ${infile_gb2} $OUTPATH/$outfile_gb2 
         if [ "$SENDDBN" = "YES" ]; then
            $DBNROOT/bin/dbn_alert MODEL NAEFS_GEFS_PQPF_BC_GB2 $job $OUTPATH/${outfile_gb2}
         fi

--- a/scripts/exnaefs_gefs_debias.sh
+++ b/scripts/exnaefs_gefs_debias.sh
@@ -242,7 +242,7 @@ for nens in $memberlist; do
 
           outfile=ge${nens}.t${cyc}z.pgrb2a.0p50_bcf${nfhrs}
           if [ -s $outfile ]; then
-            mv $outfile $COMOUTBC_p5/
+             cpfs $outfile $COMOUTBC_p5/
             $WGRIB2 -s $COMOUTBC_p5/$outfile > $COMOUTBC_p5/$outfile.idx
 
            if [ ${nfhrs} = 240 ]; then
@@ -270,7 +270,7 @@ for nens in $memberlist; do
 
           outfile=ge${nens}.t${cyc}z.pgrb2a.0p50_anf$nfhrs
           if [ -s $outfile ]; then
-            mv $outfile $COMOUTAN_p5/
+             cpfs $outfile $COMOUTAN_p5/
             # $WGRIB2 -s $COMOUTAN_p5/$outfile > $COMOUTAN_p5/$outfile.idx
             if [ "$SENDDBN" = "YES" -a $nfhrs != 000 ]; then
                MEMBER=`echo $nens | tr '[a-z]' '[A-Z]'`
@@ -281,7 +281,7 @@ for nens in $memberlist; do
 
           outfile=ge${nens}.t${cyc}z.pgrb2a.0p50_wtf$nfhrs
           if [ -s $outfile ]; then
-            mv $outfile $COMOUTWT_p5/
+             cpfs $outfile $COMOUTWT_p5/
           fi
 
           if [ "$IFENSBC1D" = "YES" ]; then
@@ -420,7 +420,7 @@ for nens in $memberlist; do
       if [ "$SENDCOM" = "YES" ]; then
         outfile=ge${nens}.t${cyc}z.pgrb2a.0p50_anf$nfhrs
         if [ -s $outfile ]; then
-          mv $outfile $COMOUTAN_p5/
+           cpfs $outfile $COMOUTAN_p5/
           # $WGRIB2 -s $COMOUTAN_p5/$outfile > $COMOUTAN_p5/$outfile.idx
           if [ "$SENDDBN" = "YES" -a $nfhrs != 000 ]; then
              MEMBER=`echo $nens | tr '[a-z]' '[A-Z]'`
@@ -443,7 +443,7 @@ for nens in $memberlist; do
       if [ "$SENDCOM" = "YES" ]; then
         outfile=ge${nens}.t${cyc}z.pgrb2a.0p50_wtf$nfhrs
         if [ -s $outfile ]; then
-          mv $outfile $COMOUTWT_p5/
+           cpfs $outfile $COMOUTWT_p5/
 #         if [ "$IFENSBC1D" = "YES" ]; then
 #           infile=ge${nens}.t${cyc}z.pgrb2a.0p50_wtf${nfhrs}
 #           outfile=ge${nens}.t${cyc}z.pgrb2a_wtf${nfhrs}

--- a/scripts/exnaefs_prob_avgspr.sh
+++ b/scripts/exnaefs_prob_avgspr.sh
@@ -83,23 +83,23 @@ if [ "$IFNAEFS" = "YES" ]; then
       for product in $prodlist; do
         oprod_gb2=${product}.t${cyc}z.pgrb2a.0p50_bcf$nfhrs
         if [ -s $oprod_gb2 ]; then
-          mv $oprod_gb2 $COMOUTNAEFS_p5/naefs_$oprod_gb2
+           cpfs $oprod_gb2 $COMOUTNAEFS_p5/naefs_$oprod_gb2
         fi
       done 
 
       oprod_gb2=geavg.t${cyc}z.pgrb2a.0p50_anvf$nfhrs
       if [ -s $oprod_gb2 ]; then
-        mv $oprod_gb2 $COMOUTNAEFSAN_p5/naefs_$oprod_gb2
+         cpfs $oprod_gb2 $COMOUTNAEFSAN_p5/naefs_$oprod_gb2
       fi
 
       oprod_gb2=geavg.t${cyc}z.pgrb2a.0p50_anf$nfhrs
       if [ -s $oprod_gb2 ]; then
-        mv $oprod_gb2 $COMOUTNAEFSAN_p5/naefs_$oprod_gb2
+         cpfs $oprod_gb2 $COMOUTNAEFSAN_p5/naefs_$oprod_gb2
       fi
 
       oprod_gb2=geefi.t${cyc}z.pgrb2a.0p50_bcf$nfhrs
       if [ -s $oprod_gb2 ]; then
-        mv $oprod_gb2 $COMOUTNAEFSAN_p5/naefs_$oprod_gb2
+         cpfs $oprod_gb2 $COMOUTNAEFSAN_p5/naefs_$oprod_gb2
       fi
 
       if [ "$IFENSBC1D" = "YES" ]; then
@@ -168,23 +168,23 @@ if [ "$IFGEFS" = "YES" ]; then
       for product in $prodlist; do
         oprod_gb2=${product}.t${cyc}z.pgrb2a.0p50_bcf$nfhrs
         if [ -s $oprod_gb2 ]; then
-          mv $oprod_gb2  $COMOUTGEFS_p5/
+           cpfs $oprod_gb2  $COMOUTGEFS_p5/
           $WGRIB2 -s $COMOUTGEFS_p5/$oprod_gb2 > $COMOUTGEFS_p5/$oprod_gb2.idx
         fi
       done 
       oprod_gb2=geavg.t${cyc}z.pgrb2a.0p50_anvf$nfhrs
       if [ -s $oprod_gb2 ]; then
-        mv $oprod_gb2  $COMOUTGEFSAN_p5/
+         cpfs $oprod_gb2  $COMOUTGEFSAN_p5/
         # $WGRIB2 -s $COMOUTGEFS_p5/$oprod_gb2 > $COMOUTGEFSAN_p5/$oprod_gb2.idx
       fi
       oprod_gb2=geavg.t${cyc}z.pgrb2a.0p50_anf$nfhrs
       if [ -s $oprod_gb2 ]; then
-        mv $oprod_gb2  $COMOUTGEFSAN_p5/
+         cpfs $oprod_gb2  $COMOUTGEFSAN_p5/
         # $WGRIB2 -s $COMOUTGEFS_p5/$oprod_gb2 > $COMOUTGEFSAN_p5/$oprod_gb2.idx
       fi
       oprod_gb2=geefi.t${cyc}z.pgrb2a.0p50_bcf$nfhrs
       if [ -s $oprod_gb2 ]; then
-        mv $oprod_gb2  $COMOUTGEFSAN_p5/
+         cpfs $oprod_gb2  $COMOUTGEFSAN_p5/
         # $WGRIB2 -s $COMOUTGEFS_p5/$oprod_gb2 > $COMOUTGEFSAN_p5/$oprod_gb2.idx
       fi
     fi

--- a/scripts/exnawips_cmce.sh
+++ b/scripts/exnawips_cmce.sh
@@ -112,7 +112,7 @@ EOF
 
   if [ $SENDCOM = "YES" ] ; then
      cp $GEMGRD $COMOUT/.$GEMGRD
-     mv $COMOUT/.$GEMGRD $COMOUT/$GEMGRD
+      cpfs $COMOUT/.$GEMGRD $COMOUT/$GEMGRD
      if [ $SENDDBN = "YES" ] ; then
          $DBNROOT/bin/dbn_alert MODEL ${DBN_ALERT_TYPE} $job \
            $COMOUT/$GEMGRD

--- a/scripts/exnawips_conus_ndgd_enscqpf.sh
+++ b/scripts/exnawips_conus_ndgd_enscqpf.sh
@@ -137,7 +137,7 @@ EOF
 
     if [ $SENDCOM = "YES" ] ; then
        cp $GEMGRD $COMOUT/.$GEMGRD
-       mv $COMOUT/.$GEMGRD $COMOUT/$GEMGRD
+        cpfs $COMOUT/.$GEMGRD $COMOUT/$GEMGRD
        if [ $SENDDBN = "YES" ] ; then
            $DBNROOT/bin/dbn_alert MODEL ${DBN_ALERT_TYPE} $job \
            $COMOUT/$GEMGRD

--- a/scripts/exnawips_fnmoc.sh
+++ b/scripts/exnawips_fnmoc.sh
@@ -175,7 +175,7 @@ fi    # if fhr=00
  #####################################################
 
  if [ $SENDCOM = "YES" ] ; then
-   mv $GEMGRD $COMOUT/$GEMGRD
+    cpfs $GEMGRD $COMOUT/$GEMGRD
    if [ $SENDDBN = "YES" ] ; then
        $DBNROOT/bin/dbn_alert MODEL ${DBN_ALERT_TYPE} $job \
          $COMOUT/$GEMGRD

--- a/scripts/exnawips_gefs_enscqpf.sh
+++ b/scripts/exnawips_gefs_enscqpf.sh
@@ -137,7 +137,7 @@ EOF
 
     if [ $SENDCOM = "YES" ] ; then
        cp $GEMGRD $COMOUT/.$GEMGRD
-       mv $COMOUT/.$GEMGRD $COMOUT/$GEMGRD
+        cpfs $COMOUT/.$GEMGRD $COMOUT/$GEMGRD
        if [ $SENDDBN = "YES" ] ; then
            $DBNROOT/bin/dbn_alert MODEL ${DBN_ALERT_TYPE} $job \
            $COMOUT/$GEMGRD

--- a/scripts/exnawips_naefs.sh
+++ b/scripts/exnawips_naefs.sh
@@ -229,7 +229,7 @@ EOF
 
     if [ $SENDCOM = "YES" ] ; then
        cp $GEMGRD $COMOUT/.$GEMGRD
-       mv $COMOUT/.$GEMGRD $COMOUT/$GEMGRD
+        cpfs $COMOUT/.$GEMGRD $COMOUT/$GEMGRD
        # if [ $SENDDBN = "YES" ] ; then
        if [ $SENDDBN = "YES" -a $model != "geavgan" -a $model != "geefi" ] ; then
            $DBNROOT/bin/dbn_alert MODEL ${DBN_ALERT_TYPE} $job \

--- a/ush/cmcens_post_avgspr.sh
+++ b/ush/cmcens_post_avgspr.sh
@@ -61,11 +61,11 @@ if [ "$SENDCOM" = "YES" ]; then
   for nfhrs in $hourlist; do
     file=cmc_geavg.t${cyc}z.pgrb2a.0p50.f${nfhrs}
     if [ -s $file ]; then
-      mv $file $COMOUT/
+      cpfs $file $COMOUT/
     fi
     file=cmc_gespr.t${cyc}z.pgrb2a.0p50.f${nfhrs}
     if [ -s $file ]; then
-      mv $file $COMOUT/
+      cpfs $file $COMOUT/
     fi
   done
 fi

--- a/ush/cmcensbc_post_avgspr.sh
+++ b/ush/cmcensbc_post_avgspr.sh
@@ -62,11 +62,11 @@ if [ "$SENDCOM" = "YES" ]; then
   for nfhrs in $hourlist; do
     file=cmc_geavg.t${cyc}z.pgrb2a.0p50_bcf${nfhrs}
     if [ -s $file ]; then
-      mv $file $COMOUTBC_GB2/
+      cpfs $file $COMOUTBC_GB2/
     fi
     file=cmc_gespr.t${cyc}z.pgrb2a.0p50_bcf${nfhrs}
     if [ -s $file ]; then
-      mv $file $COMOUTBC_GB2/
+      cpfs $file $COMOUTBC_GB2/
     fi
   done
 fi

--- a/ush/fnmocens_avgspr.sh
+++ b/ush/fnmocens_avgspr.sh
@@ -79,13 +79,13 @@ if [ "$SENDCOM" = "YES" ]; then
   do
     file=fnmoc_geavg.t${cyc}z.pgrb2a.0p50.f$nfhrs
     if [ -s $file ]; then
-      mv $file $COMOUT/
+      cpfs $file $COMOUT/
     else
       echo "Warning $file missing"
     fi
     file=fnmoc_gespr.t${cyc}z.pgrb2a.0p50.f$nfhrs
     if [ -s $file ]; then
-      mv $file $COMOUT/
+      cpfs $file $COMOUT/
     else
       echo "Warning $file missing"
     fi

--- a/ush/fnmocens_bc_avgspr.sh
+++ b/ush/fnmocens_bc_avgspr.sh
@@ -74,13 +74,13 @@ if [ "$SENDCOM" = "YES" ]; then
   do
     file=fnmoc_geavg.t${cyc}z.pgrb2a.0p50_bcf$nfhrs
     if [ -s $file ]; then
-      mv $file $COMOUTBC/
+      cpfs $file $COMOUTBC/
     else
       echo "Warning $file missing"
     fi
     file=fnmoc_gespr.t${cyc}z.pgrb2a.0p50_bcf$nfhrs
     if [ -s $file ]; then
-      mv $file $COMOUTBC/
+      cpfs $file $COMOUTBC/
     else
       echo "Warning $file missing"
     fi

--- a/ush/gefs_enspvrfy.sh
+++ b/ush/gefs_enspvrfy.sh
@@ -96,8 +96,8 @@ modelEOF
  export err=$?;err_chk
 
  cat  stat.out 
- mv stat.out    $DATA/$cyc/rain_$RUNID.$OBSYMD
-# mv obs_box.dat $DATA/obs_box_$RUNID.$YMD
+ cpfs stat.out    $DATA/$cyc/rain_$RUNID.$OBSYMD
+# cpfs obs_box.dat $DATA/obs_box_$RUNID.$YMD
 
 done
 


### PR DESCRIPTION
# Description
<!-- This description will become the commit message for the PR-->
This PR is to fix bug 1537. Improve the NAEFS scripts to use the prod_util cpfs, which copy the outputs from $DATA to $COMOUT, not mv (move). So the temporary data files or outputs created in $DATA directories are kept for records.

Resolved #19   

# Type of change
<!-- Delete all except one -->
 - [x] Bug fix (fixes something broken)
 
# Change characteristics
- Is this a breaking change (a change in existing functionality)?  NO
- Does this change require a documentation update?  NO

# How has this been tested?
 - Cycled test on WCOSS2
 
# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary