### PR TITLE
Fix bug 1520: removed variable startmsg to avoid warning message

### DIFF
--- a/jobs/JNAEFS_CMC_ENSBC_PREP
+++ b/jobs/JNAEFS_CMC_ENSBC_PREP
@@ -67,7 +67,6 @@ export USHcmce=${USHcmce:-$HOMEcmce/ush}
 export FIXcmce=${FIXcmce:-$HOMEcmce/fix}
 
 export ERRSCRIPT=err_chk
-export LOGSCRIPT=startmsg
 export REDOUT='1>>'
 export REDERR='2>'
 

--- a/jobs/JNAEFS_CMC_ENS_BIAS
+++ b/jobs/JNAEFS_CMC_ENS_BIAS
@@ -66,7 +66,6 @@ export FIXcmce=${FIXcmce:-$HOMEcmce/fix}
 export USHcmce=${USHcmce:-$HOMEcmce/ush}
 
 export ERRSCRIPT=err_chk
-export LOGSCRIPT=startmsg
 export REDOUT='1>>'
 export REDERR='2>'
 

--- a/jobs/JNAEFS_CMC_ENS_GEMPAK
+++ b/jobs/JNAEFS_CMC_ENS_GEMPAK
@@ -115,7 +115,6 @@ for nfhrs in $hourlist; do
 done
 
 chmod 775 $DATA/poescript_gempak
-startmsg
 $APRUN poescript_gempak
 export err=$?; err_chk
 

--- a/jobs/JNAEFS_CMC_ENS_POST
+++ b/jobs/JNAEFS_CMC_ENS_POST
@@ -78,7 +78,6 @@ export FIXcmce=${FIXcmce:-$HOMEcmce/fix}
 export USHcmce=${USHcmce:-$HOMEcmce/ush}
 
 export ERRSCRIPT=err_chk
-export LOGSCRIPT=startmsg
 export REDOUT='1>>'
 export REDERR='2>'
 

--- a/jobs/JNAEFS_CMC_ENS_POST_EXTEND
+++ b/jobs/JNAEFS_CMC_ENS_POST_EXTEND
@@ -78,7 +78,6 @@ export FIXcmce=${FIXcmce:-$HOMEcmce/fix}
 export USHcmce=${USHcmce:-$HOMEcmce/ush}
 
 export ERRSCRIPT=err_chk
-export LOGSCRIPT=startmsg
 export REDOUT='1>>'
 export REDERR='2>'
 

--- a/jobs/JNAEFS_DVRTMA_BIAS_ALASKA
+++ b/jobs/JNAEFS_DVRTMA_BIAS_ALASKA
@@ -71,7 +71,6 @@ export FIXrtma=${FIXrtma:-$HOMErtma/fix}
 export USHrtma=${USHrtma:-$HOMErtma/ush}
 
 export ERRSCRIPT=err_chk
-export LOGSCRIPT=startmsg
 export REDOUT='1>>'
 export REDERR='2>'
 

--- a/jobs/JNAEFS_DVRTMA_BIAS_CONUS
+++ b/jobs/JNAEFS_DVRTMA_BIAS_CONUS
@@ -71,7 +71,6 @@ export FIXrtma=${FIXrtma:-$HOMErtma/fix}
 export USHrtma=${USHrtma:-$HOMErtma/ush}
 
 export ERRSCRIPT=err_chk
-export LOGSCRIPT=startmsg
 export REDOUT='1>>'
 export REDERR='2>'
 

--- a/jobs/JNAEFS_FNMOC_ENS_BIAS
+++ b/jobs/JNAEFS_FNMOC_ENS_BIAS
@@ -93,7 +93,6 @@ export FIXfnmoc=${FIXfnmoc:-$HOMEfnmoc/fix}
 export USHfnmoc=${USHfnmoc:-$HOMEfnmoc/ush}
 
 export ERRSCRIPT=err_chk
-export LOGSCRIPT=startmsg
 export REDOUT='1>>'
 export REDERR='2>'
 

--- a/jobs/JNAEFS_FNMOC_ENS_DEBIAS
+++ b/jobs/JNAEFS_FNMOC_ENS_DEBIAS
@@ -75,7 +75,6 @@ export FIXfnmoc=${FIXfnmoc:-$HOMEfnmoc/fix}
 export USHfnmoc=${USHfnmoc:-$HOMEfnmoc/ush}
 
 export ERRSCRIPT=err_chk
-export LOGSCRIPT=startmsg
 export REDOUT='1>>'
 export REDERR='2>'
 
@@ -139,7 +138,6 @@ for nhr in $hourlist; do
 done
 
 chmod +x $DATA/poescript
-startmsg
 $APRUN $DATA/poescript
 export err=$?; err_chk
 

--- a/jobs/JNAEFS_GEFS_24HR_CQPF
+++ b/jobs/JNAEFS_GEFS_24HR_CQPF
@@ -72,7 +72,6 @@ export FIXgefs=${FIXgefs:-$HOMEgefs/fix}
 export USHgefs=${USHgefs:-$HOMEgefs/ush}
 
 export ERRSCRIPT=err_chk
-export LOGSCRIPT=startmsg
 export REDOUT='1>>'
 export REDERR='2>'
 

--- a/jobs/JNAEFS_GEFS_6HR_CQPF
+++ b/jobs/JNAEFS_GEFS_6HR_CQPF
@@ -68,7 +68,6 @@ export FIXgefs=${FIXgefs:-$HOMEgefs/fix}
 export USHgefs=${USHgefs:-$HOMEgefs/ush}
 
 export ERRSCRIPT=err_chk
-export LOGSCRIPT=startmsg
 export REDOUT='1>>'
 export REDERR='2>'
 

--- a/jobs/JNAEFS_GEFS_ANFEFI_ACPR
+++ b/jobs/JNAEFS_GEFS_ANFEFI_ACPR
@@ -80,7 +80,6 @@ export FIXgefs=${FIXgefs:-$HOMEgefs/fix}
 export USHgefs=${USHgefs:-$HOMEgefs/ush}
 
 export ERRSCRIPT=err_chk
-export LOGSCRIPT=startmsg
 export REDOUT='1>>'
 export REDERR='2>'
 

--- a/jobs/JNAEFS_GEFS_BIAS
+++ b/jobs/JNAEFS_GEFS_BIAS
@@ -113,7 +113,6 @@ export FIXgefs=${FIXgefs:-$HOMEgefs/fix}
 export USHgefs=${USHgefs:-$HOMEgefs/ush}
 
 export ERRSCRIPT=err_chk
-export LOGSCRIPT=startmsg
 export REDOUT='1>>'
 export REDERR='2>'
 

--- a/jobs/JNAEFS_GEFS_DEBIAS
+++ b/jobs/JNAEFS_GEFS_DEBIAS
@@ -81,7 +81,6 @@ export FIXgefs=${FIXgefs:-$HOMEgefs/fix}
 export USHgefs=${USHgefs:-$HOMEgefs/ush}
 
 export ERRSCRIPT=err_chk
-export LOGSCRIPT=startmsg
 export REDOUT='1>>'
 export REDERR='2>'
 
@@ -149,7 +148,6 @@ export MP_LABELIO=${MP_LABELIO:-YES}
 export MP_STDOUTMODE=${MP_STDOUTMODE:-ordered}
 
 chmod +x $DATA/poescript
-startmsg
 $APRUN $DATA/poescript
 export err=$?; err_chk
 

--- a/jobs/JNAEFS_GEFS_NDGD_CQPF
+++ b/jobs/JNAEFS_GEFS_NDGD_CQPF
@@ -76,7 +76,6 @@ export FIXndgd=${FIXndgd:-$HOMEndgd/fix}
 export USHndgd=${USHndgd:-$HOMEndgd/ush}
 
 export ERRSCRIPT=err_chk
-export LOGSCRIPT=startmsg
 export REDOUT='1>>'
 export REDERR='2>'
 

--- a/jobs/JNAEFS_GEFS_PGRB_ENSPQPF
+++ b/jobs/JNAEFS_GEFS_PGRB_ENSPQPF
@@ -76,7 +76,6 @@ export FIXgefs=${FIXgefs:-$HOMEgefs/fix}
 export USHgefs=${USHgefs:-$HOMEgefs/ush}
 
 export ERRSCRIPT=err_chk
-export LOGSCRIPT=startmsg
 export REDOUT='1>>'
 export REDERR='2>'
 

--- a/jobs/JNAEFS_GEFS_PROB_AVGSPR
+++ b/jobs/JNAEFS_GEFS_PROB_AVGSPR
@@ -148,7 +148,6 @@ chmod 775 $DATA/poescript
 # Execute the script
 #####################
 
-startmsg
 $APRUN $DATA/poescript
 export err=$?; err_chk
 

--- a/jobs/JNAEFS_PROB_AVGSPR
+++ b/jobs/JNAEFS_PROB_AVGSPR
@@ -145,7 +145,6 @@ for nfhrs in $hourlist; do
 done
 
 chmod +x $DATA/poescript_naefs
-startmsg
 $APRUN $DATA/poescript_naefs
 export err=$?; err_chk
 

--- a/scripts/exnaefs_cmc_ens_bias.sh
+++ b/scripts/exnaefs_cmc_ens_bias.sh
@@ -226,7 +226,6 @@ for nens in $memberlist; do
   fi
   ln -sf $ofile     fort.51
 
-  startmsg
   $EXECcmce/$pgm  <input.$nfhrs.$nens > $pgmout.$nfhrs.${nens} 2> errfile
   export err=$?;err_chk
 
@@ -328,7 +327,6 @@ for nfhrs in 00; do
   ln -sf $rfile_m06 fort.14
   ln -sf $ofile     fort.51
 
-  startmsg
   $EXECcmce/$pgm  <input.$nfhrs.$nens > $pgmout.$nfhrs.${nens} 2> errfile
   export err=$?;err_chk
 

--- a/scripts/exnaefs_cmcens_post.sh
+++ b/scripts/exnaefs_cmcens_post.sh
@@ -142,7 +142,6 @@ if [ $cyc -eq 00 -o $cyc -eq 12 ]; then
   done
 
   chmod +x poescript_wgrib
-  startmsg
   $APRUN poescript_wgrib
   export err=$?;err_chk
 
@@ -188,7 +187,6 @@ if [ $cyc -eq 00 -o $cyc -eq 12 ]; then
   done
 
   chmod +x poescript_cat
-  startmsg
   $APRUN poescript_cat
   export err=$?;err_chk
 
@@ -228,7 +226,6 @@ if [ $cyc -eq 00 -o $cyc -eq 12 ]; then
     done
 
     chmod +x poescript_idx
-    startmsg
     $APRUN poescript_idx
   fi
 
@@ -260,7 +257,6 @@ if [ $cyc -eq 00 -o $cyc -eq 12 ]; then
   done
 
   chmod +x poescript_alert
-  startmsg
   $APRUN poescript_alert
 
   fi

--- a/scripts/exnaefs_dvrtma_bias.sh
+++ b/scripts/exnaefs_dvrtma_bias.sh
@@ -168,7 +168,6 @@ ln -sf $afile fort.12
 ln -sf $cfile fort.13
 ln -sf $ofile fort.51
 
-startmsg
 $EXECrtma/$pgm  <input > $pgmout.$cyc
 export err=$?;err_chk
 
@@ -229,7 +228,6 @@ ofile=dvrtma.t${cycm03}z.${region}.grib2
 echo " cfopg1='${ofile}',"   >>namin_${cycm03}_dvgen
 echo " /" >>namin_${cycm03}_dvgen
 
-startmsg
 $EXECrtma/${pgm2} <namin_${cycm03}_dvgen > $pgmout.${cycm03}
 export err=$?; err_chk
 

--- a/scripts/exnaefs_dvrtma_prob_avgspr_ak.sh
+++ b/scripts/exnaefs_dvrtma_prob_avgspr_ak.sh
@@ -106,7 +106,6 @@ if [ "$SENDCOM" = "YES" ]; then
     done
   done
   chmod +x poescript_move
-  startmsg
   $APRUN_post poescript_move
 
 fi
@@ -137,7 +136,6 @@ if [ "$SENDDBN" = "YES" ]; then
           done
         done
         chmod +x poescript_alert
-        startmsg
         $APRUN_post poescript_alert
       fi
     fi
@@ -159,7 +157,6 @@ if [ "$SENDDBN" = "YES" ]; then
       done
     done
     chmod +x poescript_alert
-    startmsg
     $APRUN_post poescript_alert
   fi
 

--- a/scripts/exnaefs_dvrtma_prob_avgspr_conus.sh
+++ b/scripts/exnaefs_dvrtma_prob_avgspr_conus.sh
@@ -106,7 +106,6 @@ if [ "$SENDCOM" = "YES" ]; then
   done
 
   chmod +x poescript_move
-  startmsg
   $APRUN_post poescript_move
 
 fi
@@ -138,7 +137,6 @@ if [ "$SENDDBN" = "YES" ]; then
           done
         done
         chmod +x poescript_alert
-        startmsg
         $APRUN_post poescript_alert
       fi
     fi
@@ -160,7 +158,6 @@ if [ "$SENDDBN" = "YES" ]; then
       done
     done
     chmod +x poescript_alert
-    startmsg
     $APRUN_post poescript_alert
   fi
 

--- a/scripts/exnaefs_fnmoc_ens_bias.sh
+++ b/scripts/exnaefs_fnmoc_ens_bias.sh
@@ -205,7 +205,6 @@ for nens in $memberlist; do
   fi
   ln -sf $ofile     fort.51
 
-  startmsg
   $EXECfnmoc/$pgm  <input.$nfhrs.$nens > $pgmout.$nfhrs.${nens} 2> errfile
   export err=$?;err_chk
 
@@ -315,7 +314,6 @@ for nfhrs in 000; do
   ln -sf $rfile_m06 fort.14
   ln -sf $ofile     fort.51
 
-  startmsg
   $EXECfnmoc/$pgm  <input.$nfhrs.$nens > $pgmout.$nfhrs.${nens} 2> errfile
   export err=$?;err_chk
 
@@ -411,7 +409,6 @@ for nfhrs in 000; do
   ln -sf $cfile     fort.13
   ln -sf $ofile     fort.51
 
-  startmsg
   $EXECfnmoc/$pgm  <input.$nfhrs.$nens > $pgmout.$nfhrs.${nens} 2> ercfile
   export err=$?;err_chk
 

--- a/scripts/exnaefs_gefs_24hr_enscqpf.sh
+++ b/scripts/exnaefs_gefs_24hr_enscqpf.sh
@@ -61,7 +61,6 @@ cat inputqpf
 rm $CPGO
 
 . prep_step
-startmsg
 $EXECgefs/$pgm  <inputqpf  >$pgmout
 export err=$?;err_chk
 
@@ -115,7 +114,6 @@ cat inputpqpf
 rm $CPGO 
 
 . prep_step
-startmsg
 $EXECgefs/$pgm  <inputpqpf  >$pgmout
 export err=$?;err_chk
 

--- a/scripts/exnaefs_gefs_debias.sh
+++ b/scripts/exnaefs_gefs_debias.sh
@@ -222,7 +222,6 @@ for nens in $memberlist; do
         ln -sf $ifile_ctl fort.15
         ln -sf $ofile     fort.51
 
-        startmsg
         $EXECgefs/$pgm   <input.$nfhrs.$nens     > $pgmout.$nfhrs.$nens 2> errfile
         export err=$?;err_chk
  	rm fort.*
@@ -374,7 +373,6 @@ for nens in $memberlist; do
       ln -sf $ifile_ctl fort.15
       ln -sf $ofile     fort.51
 
-      startmsg
       $EXECgefs/$pgm   <input.$nfhrs.$nens    > $pgmout.$nfhrs.$nens 2> errfile
       export err=$?;err_chk
       rm fort.*

--- a/scripts/exnaefs_gefs_pgrb_enspqpf.sh
+++ b/scripts/exnaefs_gefs_pgrb_enspqpf.sh
@@ -91,7 +91,6 @@ cat inputpqpf
 rm $CPGO $CRAINO $CFRZRO $CICEPO $CSNOWO
 
 . prep_step
-startmsg
 $EXECgefs/$pgm  <inputpqpf  >$pgmout
 export err=$?;err_chk
 

--- a/scripts/exnawips_cmce.sh
+++ b/scripts/exnawips_cmce.sh
@@ -85,7 +85,6 @@ while [ $fhcnt -le $fend ] ; do
   cp $GRIBIN grib$fhr
 
   export pgm="nagrib2 F$fhr"
-  startmsg
 
   $GEMEXE/$NAGRIB << EOF
    GBFILE   = grib$fhr

--- a/scripts/exnawips_conus_ndgd_enscqpf.sh
+++ b/scripts/exnawips_conus_ndgd_enscqpf.sh
@@ -104,7 +104,6 @@ while [ $fhcnt -le $fend ] ; do
   if [ $skip = 0 ]; then
     cp $GRIBIN grib$fhr
 
-    startmsg
 
     $GEMEXE/$NAGRIB << EOF
     GBFILE   = grib$fhr

--- a/scripts/exnawips_gefs_enscqpf.sh
+++ b/scripts/exnawips_gefs_enscqpf.sh
@@ -104,7 +104,6 @@ while [ $fhcnt -le $fend ] ; do
   if [ $skip = 0 ]; then
     cp $GRIBIN grib$fhr
 
-    startmsg
 
     $GEMEXE/$NAGRIB << EOF
     GBFILE   = grib$fhr

--- a/scripts/exnawips_naefs.sh
+++ b/scripts/exnawips_naefs.sh
@@ -196,7 +196,6 @@ while [ $fhcnt -le $fend ] ; do
   if [ $skip = 0 ]; then
     cp $GRIBIN grib$fhr
 
-    startmsg
 
     $GEMEXE/$NAGRIB << EOF
     GBFILE   = grib$fhr

--- a/ush/cmce_adjust_tmaxmin_alaska.sh
+++ b/ush/cmce_adjust_tmaxmin_alaska.sh
@@ -174,7 +174,6 @@ for nfhrs in $hourlist; do
 done
 
 chmod +x poescript_adjust 
-startmsg
 $APRUN poescript_adjust
 export err=$?; err_chk
 

--- a/ush/cmce_adjust_tmaxmin_conus.sh
+++ b/ush/cmce_adjust_tmaxmin_conus.sh
@@ -174,7 +174,6 @@ for nfhrs in $hourlist; do
 done
 
 chmod +x poescript_adjust 
-startmsg
 $APRUN poescript_adjust 
 export err=$?; err_chk
 

--- a/ush/cmce_adjust_wind10m_alaska.sh
+++ b/ush/cmce_adjust_wind10m_alaska.sh
@@ -122,7 +122,6 @@ for mem in ${memberlist_cmc}; do
     echo "$EXECrtma/$pgm <namin.adjustcmc.$nfhrs.$mem > $pgmout.${nfhrs}.$mem" >> poescript_$mem
   done
   chmod +x poescript_$mem 
-  startmsg
   $APRUN poescript_$mem
   export err=$?; err_chk
 done

--- a/ush/cmce_adjust_wind10m_conus.sh
+++ b/ush/cmce_adjust_wind10m_conus.sh
@@ -122,7 +122,6 @@ for mem in ${memberlist_cmc}; do
     echo "$EXECrtma/$pgm <namin.adjustcmc.$nfhrs.$mem > $pgmout.${nfhrs}.$mem" >> poescript_$mem
   done
   chmod +x poescript_$mem 
-  startmsg
   $APRUN poescript_$mem 
   export err=$?; err_chk
 done

--- a/ush/cmce_climate_anomaly.sh
+++ b/ush/cmce_climate_anomaly.sh
@@ -98,7 +98,6 @@ do
  echo "ibias=$ifbias," >>input.${FHR}.${ens}_an
  echo "/" >>input.${FHR}.${ens}_an
 
- startmsg
  $EXECcmce/$pgm  <input.${FHR}.${ens}_an > $pgmout.$FHR.${ens}_an 2> errfile
  export err=$?;err_chk
 

--- a/ush/cmce_weights.sh
+++ b/ush/cmce_weights.sh
@@ -58,7 +58,6 @@ do
  echo "members=$members," >>input_$ens
  echo "/" >>input_$ens
 
- startmsg
  $EXECcmce/$pgm <input_$ens > $pgmout.$FHR.${ens}_wt 2> errfile
  export err=$?;err_chk
 

--- a/ush/cmcens_post_acc.sh
+++ b/ush/cmcens_post_acc.sh
@@ -83,7 +83,6 @@ for nens in $memberlist; do
 
   if [ -s poescript_cmc_${nens}_acc ]; then
     chmod +x poescript_cmc_${nens}_acc
-    startmsg
     $APRUN poescript_cmc_${nens}_acc
     export err=$?; err_chk
   fi

--- a/ush/cmcens_post_avgspr.sh
+++ b/ush/cmcens_post_avgspr.sh
@@ -53,7 +53,6 @@ for nfhrs in $hourlist; do
 done
 
 chmod +x poescript_avgspr
-startmsg
 $APRUN poescript_avgspr  
 export err=$?;err_chk
 

--- a/ush/cmcens_post_pqpf_24h.sh
+++ b/ush/cmcens_post_pqpf_24h.sh
@@ -19,7 +19,6 @@ fi
 export pgm=$EXECcmce/cmcens_post_pqpf_24h   
 . prep_step
 
-startmsg
 eval $pgm <<EOF >> $pgmout.cmc_pqpf 2>errfile
  &namin
  cpgb='$1',cpge='$2' /

--- a/ush/cmcens_post_stat.sh
+++ b/ush/cmcens_post_stat.sh
@@ -79,7 +79,6 @@ for var in $varlpost; do
 done
 
 chmod +x poescript_enspostc    
-startmsg
 $APRUN_post poescript_enspostc    
 export err=$?;err_chk
 
@@ -146,7 +145,6 @@ for var in $varlstat; do
 done
 
 chmod +x poescript_ensstat    
-startmsg
 $APRUN_stat poescript_ensstat    
 export err=$?;err_chk
 

--- a/ush/cmcensbc_post_avgspr.sh
+++ b/ush/cmcensbc_post_avgspr.sh
@@ -54,7 +54,6 @@ for nfhrs in $hourlist; do
 done
 
 chmod +x poescript_avgspr
-startmsg
 $APRUN poescript_avgspr  
 export err=$?;err_chk
 

--- a/ush/dvrtma_debias_3regs.sh
+++ b/ush/dvrtma_debias_3regs.sh
@@ -164,7 +164,6 @@ for nens in $outlist; do
     echo ". ./poe_${nens}.${nfhrs}" >>poescript_wgrib_$nens
   done
   chmod +x poescript_wgrib_$nens
-  startmsg
   mpirun.lsf cfp poescript_wgrib_$nens
   export err=$?;$DATA/err_chk
 
@@ -192,7 +191,6 @@ for nens in $outlist; do
   done
 
   chmod +x poescript_copygb_$nens
-  startmsg
   mpirun.lsf cfp poescript_copygb_$nens
   export err=$?;$DATA/err_chk
 
@@ -218,7 +216,6 @@ for nens in $outlist; do
     echo " copy enseble spread files "
   else
     chmod +x poescript_${nens}
-    startmsg
     mpirun.lsf cfp poescript_${nens}
     export err=$?; err_chk
   fi

--- a/ush/dvrtma_debias_alaska.sh
+++ b/ush/dvrtma_debias_alaska.sh
@@ -154,7 +154,6 @@ for nens in $outlist; do
 done
 
 chmod +x poescript_wgrib
-startmsg
 $APRUN_post poescript_wgrib
 export err=$?;err_chk
 
@@ -180,7 +179,6 @@ for nens in $outlist; do
   done
 
   chmod +x poescript_copygb_$nens
-  startmsg
   $APRUN poescript_copygb_$nens
   export err=$?;err_chk
 
@@ -214,7 +212,6 @@ for nens in $outlist; do
 done
 
 chmod +x poescript_tmpdir_02
-startmsg
 $APRUN_post poescript_tmpdir_02
 export err=$?; err_chk
 
@@ -257,7 +254,6 @@ for nfhrs in $hourlist; do
 done
 
 chmod +x poescript_cat
-startmsg
 $APRUN_post poescript_cat
 
 set +x

--- a/ush/dvrtma_debias_alaska_tmaxmin.sh
+++ b/ush/dvrtma_debias_alaska_tmaxmin.sh
@@ -89,7 +89,6 @@ if [ "$IFNAEFS" = "YES" -o  "$IFCMCE" = "YES" ]; then
       fi
     done
     chmod +x poescript_cmce
-    startmsg
     $APRUN poescript_cmce
     export err=$?; err_chk
 
@@ -125,7 +124,6 @@ if [ "$IFNAEFS" = "YES" -o  "$IFGEFS" = "YES" ]; then
   done
 
   chmod +x poescript_gefs_wgrib
-  startmsg
   $APRUN poescript_gefs_wgrib
   export err=$?; err_chk
 
@@ -142,7 +140,6 @@ if [ "$IFNAEFS" = "YES" -o  "$IFGEFS" = "YES" ]; then
   done
 
   chmod +x poescript_gefs
-  startmsg
   $APRUN poescript_gefs
   export err=$?; err_chk
 

--- a/ush/dvrtma_debias_alaska_wind10m.sh
+++ b/ush/dvrtma_debias_alaska_wind10m.sh
@@ -102,7 +102,6 @@ if [ $cyc -eq 00 -o $cyc -eq 12 ]; then
     done
 
     chmod +x poescript_cmce
-    startmsg
     $APRUN poescript_cmce
     export err=$?; err_chk
 
@@ -155,7 +154,6 @@ if [ "$IFNAEFS" = "YES" -o  "$IFGEFS" = "YES" ]; then
   done
 
   chmod +x poescript_gefs_wgrib
-  startmsg
   $APRUN poescript_gefs_wgrib
   export err=$?; err_chk
 
@@ -173,7 +171,6 @@ if [ "$IFNAEFS" = "YES" -o  "$IFGEFS" = "YES" ]; then
     fi
   done
   chmod +x poescript_gefs
-  startmsg
   $APRUN poescript_gefs
   export err=$?; err_chk
 
@@ -307,7 +304,6 @@ for nfhrs in $hourlist; do
 done
 
 chmod +x poescript_wind10m
-startmsg
 $APRUN poescript_wind10m
 export err=$?; err_chk
 

--- a/ush/dvrtma_debias_conus.sh
+++ b/ush/dvrtma_debias_conus.sh
@@ -158,7 +158,6 @@ for nens in $outlist; do
 done
 
 chmod +x poescript_wgrib
-startmsg
 $APRUN_post poescript_wgrib
 export err=$?;err_chk
 
@@ -183,7 +182,6 @@ for nens in $outlist; do
   done
 
   chmod +x poescript_copygb_$nens
-  startmsg
   $APRUN poescript_copygb_$nens
   export err=$?;err_chk
 
@@ -217,7 +215,6 @@ for nens in $outlist; do
 done
 
 chmod +x poescript_tmpdir_02
-startmsg
 $APRUN_post poescript_tmpdir_02
 export err=$?; err_chk
 
@@ -261,7 +258,6 @@ for nfhrs in $hourlist; do
 done
 
 chmod +x poescript_cat
-startmsg
 $APRUN_post poescript_cat
 
 set +x

--- a/ush/dvrtma_debias_conus_tmaxmin.sh
+++ b/ush/dvrtma_debias_conus_tmaxmin.sh
@@ -96,7 +96,6 @@ if [ "$IFNAEFS" = "YES" -o  "$IFCMCE" = "YES" ]; then
       fi
     done
 #   chmod +x poescript_cmce
-#   startmsg
 #   $APRUN poescript_cmce
 #   export err=$?; err_chk
 
@@ -132,7 +131,6 @@ if [ "$IFNAEFS" = "YES" -o  "$IFGEFS" = "YES" ]; then
   done
 
   chmod +x poescript_gefs_wgrib
-  startmsg
   $APRUN poescript_gefs_wgrib
   export err=$?; err_chk
 
@@ -159,7 +157,6 @@ if [ "$IFNAEFS" = "YES" -o  "$IFGEFS" = "YES" ]; then
   fi
 
   chmod +x poescript_gefs
-  startmsg
 # $APRUN poescript_gefs
   $APRUN_post poescript_gefs
   export err=$?; err_chk

--- a/ush/dvrtma_debias_conus_wind10m.sh
+++ b/ush/dvrtma_debias_conus_wind10m.sh
@@ -109,7 +109,6 @@ if [ $cyc -eq 00 -o $cyc -eq 12 ]; then
     done
 
 #   chmod +x poescript_cmce
-#   startmsg
 #   $APRUN poescript_cmce
 #   export err=$?; err_chk
 
@@ -162,7 +161,6 @@ if [ "$IFNAEFS" = "YES" -o  "$IFGEFS" = "YES" ]; then
   done
 
   chmod +x poescript_gefs_wgrib
-  startmsg
   $APRUN poescript_gefs_wgrib
   export err=$?; err_chk
 
@@ -191,7 +189,6 @@ if [ "$IFNAEFS" = "YES" -o  "$IFGEFS" = "YES" ]; then
   fi
 
   chmod +x poescript_gefs
-  startmsg
 # $APRUN poescript_gefs
   $APRUN_post poescript_gefs
   export err=$?; err_chk
@@ -326,7 +323,6 @@ for nfhrs in $hourlist; do
 done
 
 chmod +x poescript_wind10m
-startmsg
 $APRUN poescript_wind10m
 export err=$?; err_chk
 

--- a/ush/fnmocens_avgspr.sh
+++ b/ush/fnmocens_avgspr.sh
@@ -70,7 +70,6 @@ for nfhrs in $hourlist; do
 done
 
 chmod +x poescript_avgspr
-startmsg
 $APRUN poescript_avgspr
 export err=$?; err_chk
 

--- a/ush/fnmocens_bc_avgspr.sh
+++ b/ush/fnmocens_bc_avgspr.sh
@@ -65,7 +65,6 @@ for nfhrs in $hourlist; do
 done
 
 chmod +x poescript_avgspr
-startmsg
 $APRUN poescript_avgspr
 export err=$?; err_chk
 

--- a/ush/fnmocens_climate_anomaly.sh
+++ b/ush/fnmocens_climate_anomaly.sh
@@ -92,7 +92,6 @@ do
  echo "ibias=$ifbias," >>input_$ens
  echo "/" >>input_$ens
 
- startmsg
  $EXECfnmoc/$pgm  <input_$ens >$pgmout.$FHR.${ens}_an 2> errfile
  export err=$?
  if [ $err -eq 0 ]; then

--- a/ush/fnmocens_weights.sh
+++ b/ush/fnmocens_weights.sh
@@ -43,7 +43,6 @@ do
  echo "members=$members," >>input_$ens
  echo "/" >>input_$ens
 
- startmsg
  $EXECfnmoc/$pgm         <input_$ens > $pgmout.$FHR.${ens}_wt 2> errfile
  export err=$?;err_chk
 

--- a/ush/gefs_anfefi_acpr.sh
+++ b/ush/gefs_anfefi_acpr.sh
@@ -43,7 +43,6 @@ do
    echo "canom='anom.dat'," >>input
    echo "/" >>input
 
-   startmsg
    $EXECGEFS/$pgm <input > $pgmout.$FHR_an 2> errfile
    export err=$?;err_chk
 

--- a/ush/gefs_bias_coeff.sh
+++ b/ush/gefs_bias_coeff.sh
@@ -285,7 +285,6 @@ for nens in $memlist; do
   ln -sf $osfabar     fort.44
   ln -sf $or2         fort.45
 
-  startmsg
   $EXECgefs/$pgm  <input.r2.$nfhrs.$nens > $pgmout.coeff.$nfhrs.${nens} 2> errfile
   export err=$?;err_chk
 

--- a/ush/gefs_bias_coeff_avggen.sh
+++ b/ush/gefs_bias_coeff_avggen.sh
@@ -98,7 +98,6 @@ for nens in $memlist; do
 
   if [ -s poescript_coeff_${nens} ]; then
     chmod +x poescript_coeff_${nens}
-    startmsg
     $APRUN poescript_coeff_${nens}
     export err=$?; err_chk
   fi

--- a/ush/gefs_bias_combine.sh
+++ b/ush/gefs_bias_combine.sh
@@ -132,7 +132,6 @@ if [ "$IF_REFCSTWITH" = "YES" ]; then
     ln -sf $ibias_rf  fort.13
     ln -sf $ofile     fort.51
 
-    startmsg
     $EXECgefs/$pgm   <input.avg.$nfhrs     > $pgmout.mecom.$nfhrs 2> errfile
     export err=$?;err_chk
 

--- a/ush/gefs_bias_decay.sh
+++ b/ush/gefs_bias_decay.sh
@@ -210,7 +210,6 @@ for nens in $memberlist; do
   ln -sf $cfile       fort.14
   ln -sf $ofile       fort.51
 
-  startmsg
   $EXECgefs/$pgm <input.$nfhrs.$nens > $pgmout.$nfhrs.${nens} 2> errfile
   export err=$?;err_chk
 
@@ -333,7 +332,6 @@ for nfhrs in 00; do
   ln -sf $rfile_m06 fort.15
   ln -sf $ofile     fort.51
 
-  startmsg
   $EXECgefs/$pgm <input.$nfhrs.$nens > $pgmout.$nfhrs.${nens} 2> errfile
   export err=$?;err_chk
 
@@ -458,7 +456,6 @@ for nfhrs in 00; do
   ln -sf $cfile_m12     fort.15
   ln -sf $ofile         fort.51
 
-  startmsg
   $EXECgefs/$pgm  <input.$nfhrs.$nens > $pgmout.$nfhrs.${nens} 2> ercfile
   export err=$?;err_chk
 

--- a/ush/gefs_bias_decay_avggen.sh
+++ b/ush/gefs_bias_decay_avggen.sh
@@ -92,7 +92,6 @@ for nens in $memberlist; do
 
   if [ -s poescript_bias_${nens} ]; then
     chmod +x poescript_bias_${nens}
-    startmsg
     $APRUN poescript_bias_${nens}
 #   $APRUN_32 poescript_bias_${nens}
     export err=$?; err_chk

--- a/ush/gefs_bias_reforecast.sh
+++ b/ush/gefs_bias_reforecast.sh
@@ -80,7 +80,6 @@ done
 
 chmod +x poescript_wgrib_rfbias
 
-startmsg
 $APRUN poescript_wgrib_rfbias
 export err=$?;err_chk
 
@@ -109,7 +108,6 @@ done
 
 chmod +x poescript_copygb_rfbias
 
-startmsg
 $APRUN poescript_copygb_rfbias
 export err=$?;err_chk
 
@@ -195,7 +193,6 @@ done
 
 if [ -s poescript_avggen_rfbias ]; then
   chmod +x poescript_avggen_rfbias
-  startmsg
   $APRUN poescript_avggen_rfbias
   export err=$?; err_chk
 fi

--- a/ush/gefs_climate_anomaly.sh
+++ b/ush/gefs_climate_anomaly.sh
@@ -84,7 +84,6 @@ do
  echo "ibias=$ifbias," >>input.${FHR}.${ens}_an
  echo "/" >>input.${FHR}.${ens}_an
 
- startmsg
  $EXECgefs/$pgm <input.${FHR}.${ens}_an > $pgmout.$FHR.${ens}_an 2> errfile
  export err=$?;err_chk
 

--- a/ush/gefs_enscqpf.sh
+++ b/ush/gefs_enscqpf.sh
@@ -49,7 +49,6 @@ cat input_cqpf_$fhrs
 
  . prep_step
 
-  startmsg
 
  $EXECgefs/gefs_enscqpf_6hr <input_cqpf_$fhrs   >> $pgmout 2>errfile
  export err=$?;err_chk

--- a/ush/gefs_enspvrfy.sh
+++ b/ush/gefs_enspvrfy.sh
@@ -90,7 +90,6 @@ modelEOF
  export pgm=gefs_enspvrfy
  . prep_step
 
-  startmsg
 
  $EXECgefs/gefs_enspvrfy  <input_runv   >> $pgmout 2>errfile
  export err=$?;err_chk

--- a/ush/gefs_enssrbias.sh
+++ b/ush/gefs_enssrbias.sh
@@ -65,7 +65,6 @@ if [ $inew -eq 1 ]; then
  export pgm=gefs_enssrbias
  . prep_step
 
-  startmsg
 
  $EXECgefs/gefs_enssrbias <input_stat >stat_output.$RID
  export err=$?; err_chk

--- a/ush/gefs_weights.sh
+++ b/ush/gefs_weights.sh
@@ -41,7 +41,6 @@ do
  echo "members=$members," >>input.${FHR}.${ens}_wt
  echo "/" >>input.${FHR}.${ens}_wt
 
- startmsg
  $EXECgefs/gefs_weights <input.${FHR}.${ens}_wt >${pgmout}.$FHR.${ens}_wt     
  export err=$?;err_chk
 

--- a/ush/global_ensstat_cmc.sh
+++ b/ush/global_ensstat_cmc.sh
@@ -71,7 +71,6 @@ do
 
     cat namin
 
-    startmsg
     $EXECcmce/$pgm <namin>$pgmout 2>errfile
     export err=$?; err_chk
     mv namin namin.$var.lr

--- a/ush/naefs_bc_probability.sh
+++ b/ush/naefs_bc_probability.sh
@@ -588,7 +588,6 @@ for nfhrs in $hourlist; do
     export err=1; err_chk
   fi
 
-  startmsg
   $EXECnaefs/naefs_bc_probability <namin.prob.$nfhrs > $pgmout.${nfhrs}_prob  2> errfile
   export err=$?;err_chk
 

--- a/ush/naefs_climate_anomaly.sh
+++ b/ush/naefs_climate_anomaly.sh
@@ -87,7 +87,6 @@ do
  echo "ibias=$ifbias," >>input.${FHR}.${ens}_an
  echo "/" >>input.${FHR}.${ens}_an
 
- startmsg
  $EXECnaefs/$pgm <input.${FHR}.${ens}_an > $pgmout.$FHR.${ens}_anf 2> errfile
  export err=$?;err_chk
 

--- a/ush/naefs_climate_anv.sh
+++ b/ush/naefs_climate_anv.sh
@@ -84,7 +84,6 @@ do
  echo "ibias=$ifbias," >>input_$ens.$FHR
  echo "/" >>input_$ens.$FHR
 
- startmsg
  $EXECnaefs/$pgm <input_$ens.$FHR > $pgmout.$FHR.${ens}_an 2> errfile
  export err=$?;err_chk
 

--- a/ush/naefs_climate_efi.sh
+++ b/ush/naefs_climate_efi.sh
@@ -85,7 +85,6 @@ do
 
 #  excute program
 
-    startmsg
     $EXECnaefs/$pgm  <input.${FHR}.${ens}_anfefi > $pgmout.$FHR.${ens}_anfefi 2> errfile
     export err=$?;err_chk
 


### PR DESCRIPTION
# Description
<!-- This description will become the commit message for the PR-->
This PR is to fix bug 1520: removed variable startmsg to avoid warning messages.
There are a lot of "WARNING: pgm variable not defined" messages in the log files. It is caused by calling 'startmsg' without exporting the pgm first.  Some scripts call "startmsg" before run a poe script, where wgrib2 or copygb will be used. Therefore no pgm was defined. The line containing "startmsg" are removed to avoid the the warning message.

Resolved #11 

# Type of change
<!-- Delete all except one -->
 - [x] Bug fix (fixes something broken)
 
# Change characteristics
- Is this a breaking change (a change in existing functionality)?  NO
- Does this change require a documentation update?  NO

# How has this been tested?
 - Cycled test on WCOSS2
 
# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary