### PR TITLE
Fix Bug 1525 - Improve NAEFS bias and debias scripts error handlings

### DIFF
--- a/ush/conus_ndgd_enswgrp.sh
+++ b/ush/conus_ndgd_enswgrp.sh
@@ -29,5 +29,6 @@ outfile=$DATA/$cyc/${iacc}hr/geprcp.t${cyc}z.ndgd2p5.bc_${iacc}hf${nfhrs}.gb2
     echo "echo "no file of" $infile "          
     echo " ***** Missing today's precipitation forecast *****"
     echo " ***** Program must be stoped here !!!!!!!!!! *****"
+    echo "FATAL ERROR in conus_ndgd_enswgrp.sh !!!"
     export err=8; err_chk
   fi

--- a/ush/dvrtma_debias_3regs.sh
+++ b/ush/dvrtma_debias_3regs.sh
@@ -125,6 +125,8 @@ for nens in $outlist; do
     fi
 
     if [[ ! -s $infile ]]; then
+      ls $infile
+      echo "FATAL ERROR in dvrtma_debias_3regs.sh !!!"
       echo "Input pgrb2a_bc files not available"
       export err=1; err_chk
     fi

--- a/ush/dvrtma_debias_alaska.sh
+++ b/ush/dvrtma_debias_alaska.sh
@@ -113,7 +113,9 @@ for nens in $outlist; do
     fi
 
     if [[ ! -s $infile ]]; then
-      echo "Warning !!! Input pgrb2ap5_bc files not available"
+      ls $$infile
+      echo "FATAL ERROR in dvrtma_debias_alaska.sh !!!"
+      echo "Input pgrb2ap5_bc files not available"
       export err=1; err_chk
     fi
 

--- a/ush/dvrtma_debias_conus.sh
+++ b/ush/dvrtma_debias_conus.sh
@@ -117,7 +117,9 @@ for nens in $outlist; do
     fi
 
     if [[ ! -s $infile ]]; then
-      echo "Warning !!! Input pgrb2ap5_bc files not available"
+      ls $$infile
+      echo "FATAL ERROR in dvrtma_debias_conus.sh !!!"
+      echo "Input pgrb2ap5_bc files not available"
       export err=1; err_chk
     fi
 

--- a/ush/gefs_enscqpf.sh
+++ b/ush/gefs_enscqpf.sh
@@ -56,6 +56,7 @@ cat input_cqpf_$fhrs
 else
  echo " ***** Missing today's precipitation forecast *****"
  echo " ***** Program must be stoped here !!!!!!!!!! *****"
+ echo "FATAL ERROR in gefs_enscqpf.sh !!!"
  export err=8;err_chk
 fi
 

--- a/ush/gefs_ensgetgrp.sh
+++ b/ush/gefs_ensgetgrp.sh
@@ -67,6 +67,7 @@ for nfhrs in $hourlist; do
   else
       echo " No either $infile" 
       echo " Missing precipitation forecast data detected, quit "
+#     echo "FATAL ERROR in gefs_ensgetgrp.sh !!!"
 #      export err=8; err_chk
   fi     
   done
@@ -81,5 +82,6 @@ for nfhrs in $hourlist; do
   else
       echo " No either $infile"
       echo " Missing precipitation forecast data detected, quit "
+#     echo "FATAL ERROR in gefs_ensgetgrp.sh !!!"
 #     export err=8; err_chk
   fi     

--- a/ush/gefs_ensgetgrp.sh
+++ b/ush/gefs_ensgetgrp.sh
@@ -67,7 +67,7 @@ for nfhrs in $hourlist; do
   else
       echo " No either $infile" 
       echo " Missing precipitation forecast data detected, quit "
-#     echo "FATAL ERROR in gefs_ensgetgrp.sh !!!"
+      echo "FATAL ERROR in gefs_ensgetgrp.sh !!!"
 #      export err=8; err_chk
   fi     
   done
@@ -82,6 +82,6 @@ for nfhrs in $hourlist; do
   else
       echo " No either $infile"
       echo " Missing precipitation forecast data detected, quit "
-#     echo "FATAL ERROR in gefs_ensgetgrp.sh !!!"
+      echo "FATAL ERROR in gefs_ensgetgrp.sh !!!"
 #     export err=8; err_chk
   fi     

--- a/ush/gefs_enswgrp.sh
+++ b/ush/gefs_enswgrp.sh
@@ -46,6 +46,7 @@ fi
     echo "echo "no file of" $infile "          
     echo " ***** Missing today's precipitation forecast *****"
     echo " ***** Program must be stoped here !!!!!!!!!! *****"
+    echo "FATAL ERROR in gefs_enswgrp.sh !!!"
     export err=8; err_chk
     fi     
   done    # for nens in $memberlist


### PR DESCRIPTION
# Description
<!-- This description will become the commit message for the PR-->
This PR is to fix bug 1525 that Improves NAEFS bias and debias scripts error handling. When “export err=8; err_chk” happens for ush scripts to fail the job, add “FATAL ERROR:” in the descriptive messages. The below ush scripts are modified. 

ush/conus_ndgd_enswgrp.sh
ush/gefs_enscqpf.sh
ush/gefs_ensgetgrp.sh
ush/gefs_ensgetgrp.sh
ush/gefs_enswgrp.sh 
ush/dvrtma_debias_alaska.sh
ush/dvrtma_debias_conus.sh
ush/dvrtma_debias_3regs.sh

Resolved #15 

# Type of change
<!-- Delete all except one -->
 - [ ] Bug fix (fixes something broken)
 
# Change characteristics
- Is this a breaking change (a change in existing functionality)?  NO
- Does this change require a documentation update?  NO

# How has this been tested?
 - Cycled test on WCOSS2
 
# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary