### PR TITLE
Add restart capability to NAEFS post-process jobs/scripts

### DIFF
--- a/jobs/JNAEFS_CMC_ENS_GEMPAK
+++ b/jobs/JNAEFS_CMC_ENS_GEMPAK
@@ -71,6 +71,9 @@ setpdy.sh
 export COMIN=${COMIN:-$(compath.py $envir/$NET/${naefs_ver})/${RUN}.${PDY}/${cyc}/pgrb2ap5}
 export COMOUT=${COMOUT:-$(compath.py -o $NET/${naefs_ver})/${RUN}.${PDY}/gempak}
 
+# Create a restart directory in ptmp to hold temporary output
+export DATA_RESTART=${DATAROOT}/$NET/${naefs_ver}/${RUN}.${PDY}/${cyc}/restart
+if [[ ! -d ${DATA_RESTART} ]]; then mkdir -p "${DATA_RESTART}"; fi
 
 if [ ! -f $COMOUT ] ; then
   mkdir -p -m 775 $COMOUT
@@ -128,5 +131,6 @@ cat $DATA/dir_360/output_avg_360
 cd $DATAROOT
 
 if [ $KEEPDATA = NO ]; then rm -rf $DATA; fi
+#rm -rf DATA_RESTART
 
 date

--- a/jobs/JNAEFS_CMC_ENS_POST
+++ b/jobs/JNAEFS_CMC_ENS_POST
@@ -101,6 +101,10 @@ export COMOUT=$COM_OUT/${RUN}.${PDY}/${cyc}/pgrb2ap5
 export COMOUTm1=$COM_OUT/${RUN}.${PDYm1}/${cyc}/pgrb2ap5
 export COMOUTenst=$COM_OUT/${RUN}.${PDY}/${cyc}/ensstat
 
+# Create a restart directory in ptmp to hold temporary output
+export DATA_RESTART=${DATAROOT}/$NET/${naefs_ver}/${RUN}.${PDY}/${cyc}/restart
+if [[ ! -d ${DATA_RESTART} ]]; then mkdir -p "${DATA_RESTART}"; fi
+
 mkdir -m 775 -p $COMOUT
 mkdir -m 775 -p $COMOUTm1             
 mkdir -m 775 -p $COMOUTenst 
@@ -133,5 +137,8 @@ if [ $KEEPDATA != YES ]; then
   cd $DATAROOT
   rm -rf $DATA
 fi
+# rm -rf $DATA_RESTART
+
+
 
 date

--- a/jobs/JNAEFS_FNMOC_ENS_GEMPAK
+++ b/jobs/JNAEFS_FNMOC_ENS_GEMPAK
@@ -95,6 +95,10 @@ export COMIN_bc=$COMIN/fnmoc_0p5_ens_bc_gb2
 
 export COMOUT=${COMOUT:-$(compath.py -o $NET/${naefs_ver})/${RUN}.${PDY}/gempak}
 
+# Create a restart directory in ptmp to hold temporary output
+export DATA_RESTART=${DATAROOT}/$NET/${naefs_ver}/${RUN}.${PDY}/${cyc}/restart
+if [[ ! -d ${DATA_RESTART} ]]; then mkdir -p "${DATA_RESTART}"; fi
+
 if [ ! -f $COMOUT ] ; then
   mkdir -p -m 775 $COMOUT
 fi
@@ -131,6 +135,9 @@ cat $DATA/11_et/output
 ##############################
 cd $DATAROOT
 
-if [ $KEEPDATA = NO ]; then rm -rf $DATA; fi
+if [ $KEEPDATA = NO ]; then
+  rm -rf $DATA
+# rm -rf $DATA_RESTART
+fi
 
 date

--- a/jobs/JNAEFS_GEFS_BIAS_GEMPAK
+++ b/jobs/JNAEFS_GEFS_BIAS_GEMPAK
@@ -73,6 +73,10 @@ export COMIN_ANL=${COMIN_ANL:-$(compath.py $envir/$NET/${naefs_ver})/${RUN}.${PD
 export COMOUT=${COMOUT:-$(compath.py -o $NET/${naefs_ver})/${RUN}.${PDY}/gempak}
 export COMOUTm2=${COMOUTm2:-$(compath.py -o $NET/${naefs_ver})/${RUN}.${PDYm2}/gempak}
 
+# Create a restart directory in ptmp to hold temporary output
+export DATA_RESTART=${DATAROOT}/$NET/${naefs_ver}/${RUN}.${PDY}/${cyc}/restart
+if [[ ! -d ${DATA_RESTART} ]]; then mkdir -p "${DATA_RESTART}"; fi
+
 if [ ! -f $COMOUT ] ; then
   mkdir -p -m 775 $COMOUT
 fi
@@ -101,9 +105,14 @@ $APRUN $DATA/poescript
 export err=$?; err_chk
 
 ########################################################
+cd $DATA
+cat avg_mecom/output
+cat gfs_me/output
+cat gefs_anl/output
 
 cd $DATAROOT
 
 if [ $KEEPDATA = NO ]; then rm -rf $DATA; fi
+#rm -rf $DATA_RESTART
 
 date

--- a/jobs/JNAEFS_GEFS_DEBIAS
+++ b/jobs/JNAEFS_GEFS_DEBIAS
@@ -107,6 +107,10 @@ export COMOUTBC=${COM_OUT}/${RUN}.${PDY}/${cyc}/pgrb2a_bc
 export COMOUTAN=${COM_OUT}/${RUN}.${PDY}/${cyc}/pgrb2a_an
 export COMOUTWT=${COM_OUT}/${RUN}.${PDY}/${cyc}/pgrb2a_wt
 
+# Create a restart directory in ptmp to hold temporary output
+export DATA_RESTART=${DATAROOT}/$NET/${naefs_ver}/${RUN}.${PDY}/${cyc}/restart
+if [[ ! -d ${DATA_RESTART} ]]; then mkdir -p "${DATA_RESTART}"; fi
+
 mkdir -m 775 -p ${COMOUTBC_p5}
 mkdir -m 775 -p ${COMOUTAN_p5}
 mkdir -m 775 -p ${COMOUTWT_p5}
@@ -168,6 +172,8 @@ if [ $KEEPDATA != YES ]; then
   cd $DATAROOT
   rm -rf $DATA
 fi
+
+#rm -rf $DATA_RESTART
 
 date
 

--- a/jobs/JNAEFS_GEFS_DEBIAS_GEMPAK
+++ b/jobs/JNAEFS_GEFS_DEBIAS_GEMPAK
@@ -77,6 +77,10 @@ export COMIN_BC=${COMIN_BC:-$(compath.py $envir/$NET/${naefs_ver})/${RUN}.${PDY}
 export COMIN_AN=${COMIN_AN:-$(compath.py $envir/$NET/${naefs_ver})/${RUN}.${PDY}/${cyc}/pgrb2ap5_an}
 export COMOUT=${COMOUT:-$(compath.py -o $NET/${naefs_ver})/${RUN}.${PDY}/gempak}
 
+# Create a restart directory in ptmp to hold temporary output
+export DATA_RESTART=${DATAROOT}/$NET/${naefs_ver}/${RUN}.${PDY}/${cyc}/restart
+if [[ ! -d ${DATA_RESTART} ]]; then mkdir -p "${DATA_RESTART}"; fi
+
 if [ ! -f $COMOUT ] ; then
   mkdir -p -m 775 $COMOUT $COMOUT/an  $COMOUT/bc
 fi
@@ -110,12 +114,12 @@ for nfhrs in $hourlist; do
       if [ $member != gfs ]; then
         echo "${HOMEnaefs}/scripts/exnawips_naefs.sh $DATA/dir_${ftype}_${nfhrs} \
               $nfhrs $nfhrs $COMIN $COMOUT/${ftype} ge${member} $ftype NAEFS_GEFS_GEMPAK &> \
-              $DATA/dir_${ftype}_${nfhrs}/output" >> $DATA/poe_gempak_${ftype}_${nfhrs}
+              $DATA/dir_${ftype}_${nfhrs}/output_${ftype}_${nfhrs}" >> $DATA/poe_gempak_${ftype}_${nfhrs}
       else
         if [ $nfhrs -le 180 ]; then
           echo "${HOMEnaefs}/scripts/exnawips_naefs.sh $DATA/dir_${ftype}_${nfhrs} \
                 $nfhrs $nfhrs $COMIN $COMOUT/${ftype} ge${member} $ftype NAEFS_GEFS_GEMPAK &> \
-                $DATA/dir_${ftype}_${nfhrs}/output" >> $DATA/poe_gempak_${ftype}_${nfhrs}
+                $DATA/dir_${ftype}_${nfhrs}/output_${ftype}_${nfhrs}" >> $DATA/poe_gempak_${ftype}_${nfhrs}
         else
           echo "echo "Skip the GFS forecast file " " >> $DATA/poe_gempak_${ftype}_${nfhrs}                   
         fi
@@ -139,15 +143,16 @@ $APRUN $DATA/poescript_gempak
 export err=$?; err_chk
 
 cd $DATA
-cat dir_bc_006/output 
-cat dir_bc_384/output 
-cat dir_an_006/output 
-cat dir_an_384/output 
+cat dir_bc_006/output_bc_006 
+cat dir_bc_384/output_bc_384
+cat dir_an_006/output_an_006
+cat dir_an_384/output_an_384 
 
 ########################################################
 
 cd $DATAROOT
 
 if [ $KEEPDATA = NO ]; then rm -rf $DATA; fi
+#rm -rf $DATA_RESTART
 
 date

--- a/jobs/JNAEFS_GEFS_PROB_AVGSPR
+++ b/jobs/JNAEFS_GEFS_PROB_AVGSPR
@@ -107,6 +107,10 @@ export COMOUTGEFSAN_p5=${COM_OUT}/${RUN}.${PDY}/${cyc}/pgrb2ap5_an
 export COMOUTGEFS=${COM_OUT}/${RUN}.${PDY}/${cyc}/pgrb2a_bc
 export COMOUTGEFSAN=${COM_OUT}/${RUN}.${PDY}/${cyc}/pgrb2a_an
 
+# Create a restart directory in ptmp to hold temporary output
+export DATA_RESTART=${DATAROOT}/$NET/${naefs_ver}/${RUN}.${PDY}/${cyc}/restart
+if [[ ! -d ${DATA_RESTART} ]]; then mkdir -p "${DATA_RESTART}"; fi
+
 mkdir -m 775 -p ${COMOUTGEFS_p5}
 mkdir -m 775 -p ${COMOUTGEFSAN_p5}
 
@@ -179,5 +183,6 @@ if [ $KEEPDATA != YES ]; then
   cd $DATAROOT
   rm -rf $DATA
 fi
+#rm -rf $DATA_RESTART
 
 date

--- a/jobs/JNAEFS_GEFS_PROB_AVGSPR_GEMPAK
+++ b/jobs/JNAEFS_GEFS_PROB_AVGSPR_GEMPAK
@@ -72,6 +72,9 @@ export COMIN_BC=${COMIN_BC:-$(compath.py $envir/$NET/${naefs_ver})/${RUN}.${PDY}
 export COMIN_ANV=${COMIN_ANV:-$(compath.py $envir/$NET/${naefs_ver})/${RUN}.${PDY}/${cyc}/pgrb2ap5_an}
 export COMOUT=${COMOUT:-$(compath.py -o $NET/${naefs_ver})/${RUN}.${PDY}/gempak}
 
+# Create a restart directory in ptmp to hold temporary output
+export DATA_RESTART=${DATAROOT}/$NET/${naefs_ver}/${RUN}.${PDY}/${cyc}/restart
+if [[ ! -d ${DATA_RESTART} ]]; then mkdir -p "${DATA_RESTART}"; fi
 
 if [ ! -f $COMOUT ] ; then
   mkdir -p -m 775 $COMOUT
@@ -143,5 +146,6 @@ cat $DATA/dir_384/output_geefi_bc_384
 cd $DATAROOT
 
 if [ $KEEPDATA = NO ]; then rm -rf $DATA; fi
+#rm -rf DATA_RESTART
 
 date

--- a/jobs/JNAEFS_PROB_AVGSPR
+++ b/jobs/JNAEFS_PROB_AVGSPR
@@ -107,6 +107,10 @@ export COMOUTNAEFSAN_p5=${COM_OUT}/${RUN}.${PDY}/${cyc}/pgrb2ap5_an
 export COMOUTNAEFS=${COM_OUT}/${RUN}.${PDY}/${cyc}/pgrb2a_bc
 export COMOUTNAEFSAN=${COM_OUT}/${RUN}.${PDY}/${cyc}/pgrb2a_an
 
+# Create a restart directory in ptmp to hold temporary output
+export DATA_RESTART=${DATAROOT}/$NET/${naefs_ver}/${RUN}.${PDY}/${cyc}/restart
+if [[ ! -d ${DATA_RESTART} ]]; then mkdir -p "${DATA_RESTART}"; fi
+
 mkdir -m 775 -p ${COMOUTNAEFS_p5}
 mkdir -m 775 -p ${COMOUTNAEFSAN_p5}
 
@@ -167,6 +171,7 @@ postmsg "$jlogfile" "$msg"
 if [ $KEEPDATA != YES ]; then
   cd $DATAROOT
   rm -rf $DATA
+# rm -rf $DATA_RESTART
 fi
 
 date

--- a/jobs/JNAEFS_PROB_AVGSPR_GEMPAK
+++ b/jobs/JNAEFS_PROB_AVGSPR_GEMPAK
@@ -74,6 +74,10 @@ export COMIN_BC=${COMIN_BC:-$(compath.py $envir/$NET/${naefs_ver})/${RUN}.${PDY}
 export COMIN_AN=${COMIN_AN:-$(compath.py $envir/$NET/${naefs_ver})/${RUN}.${PDY}/${cyc}/pgrb2ap5_an}
 export COMOUT=${COMOUT:-$(compath.py -o $NET/${naefs_ver})/${RUN}.${PDY}/gempak}
 
+# Create a restart directory in ptmp to hold temporary output
+export DATA_RESTART=${DATAROOT}/$NET/${naefs_ver}/${RUN}.${PDY}/${cyc}/restart
+if [[ ! -d ${DATA_RESTART} ]]; then mkdir -p "${DATA_RESTART}"; fi
+
 if [ ! -f $COMOUT ] ; then
   mkdir -p -m 775 $COMOUT
 fi
@@ -158,5 +162,6 @@ cat $DATA/dir_384/output_geavg_bc_384
 cd $DATAROOT
 
 if [ $KEEPDATA = NO ]; then rm -rf $DATA; fi
+#rm -rf $DATA_RESTART
 
 date

--- a/scripts/exnaefs_cmcens_post.sh
+++ b/scripts/exnaefs_cmcens_post.sh
@@ -66,6 +66,12 @@ fi
 export memberlist="p01 p02 p03 p04 p05 p06 p07 p08 p09 p10 \
                    p11 p12 p13 p14 p15 p16 p17 p18 p19 p20 c00"
 
+# Count the number of members
+count=$(echo $memberlist | wc -w)
+
+# Print the result
+echo "Number of members: $count"
+
 if [ $cyc -eq 00 -o $cyc -eq 12 ]; then
 
 ##########################################
@@ -202,6 +208,7 @@ if [ $cyc -eq 00 -o $cyc -eq 12 ]; then
 
   ecflow_client --event release_debias
 
+  # generate idx files
 
   if [ $SENDDBN_GB2 = YES ]; then
     for nfhrs in $hourlist; do
@@ -229,37 +236,66 @@ if [ $cyc -eq 00 -o $cyc -eq 12 ]; then
     $APRUN poescript_idx
   fi
 
+  # send out alerts     
+
   if [ $SENDDBN_GB2 = YES ]; then
+
+    if [ -s poescript_alert ]; then
+      rm poescript_alert
+    fi
+
     for nfhrs in $hourlist; do
+
+    # if this is a rerun, a directory DATA_RESTART must exist with data in it
+    logfile=naefs_cmcens_post_${PDY}${cyc}.logf${nfhrs}
+   
+    if [ -s ${DATA_RESTART}/${logfile} ]; then
+      echo "Restarts found in ${DATA_RESTART} logfile=${logfile}"
+    else
+  
+    # start to sent alert
+
       ifile_avg=cmc_geavg.t${cyc}z.pgrb2a.0p50.f${nfhrs}
-
-      echo "$DBNROOT/bin/dbn_alert MODEL NAEFS_CMCENS_PGBA_GB2      $job $COMOUT/${ifile_avg}"     >>poe_alert.${nfhrs} 
-      echo "$DBNROOT/bin/dbn_alert MODEL NAEFS_CMCENS_PGBA_GB2_WIDX $job $COMOUT/${ifile_avg}.idx" >>poe_alert.${nfhrs} 
-
       ifile_spr=cmc_gespr.t${cyc}z.pgrb2a.0p50.f${nfhrs}
-      echo "$DBNROOT/bin/dbn_alert MODEL NAEFS_CMCENS_PGBA_GB2      $job $COMOUT/${ifile_spr}"     >>poe_alert.${nfhrs} 
-      echo "$DBNROOT/bin/dbn_alert MODEL NAEFS_CMCENS_PGBA_GB2_WIDX $job $COMOUT/${ifile_spr}.idx" >>poe_alert.${nfhrs} 
 
+      if [ -s $COMOUT/${ifile_avg} -a -s $COMOUT/${ifile_spr} ]; then
+
+        echo "$DBNROOT/bin/dbn_alert MODEL NAEFS_CMCENS_PGBA_GB2      $job $COMOUT/${ifile_avg}"     >>poe_alert.${nfhrs} 
+        echo "$DBNROOT/bin/dbn_alert MODEL NAEFS_CMCENS_PGBA_GB2_WIDX $job $COMOUT/${ifile_avg}.idx" >>poe_alert.${nfhrs} 
+        echo "$DBNROOT/bin/dbn_alert MODEL NAEFS_CMCENS_PGBA_GB2      $job $COMOUT/${ifile_spr}"     >>poe_alert.${nfhrs} 
+        echo "$DBNROOT/bin/dbn_alert MODEL NAEFS_CMCENS_PGBA_GB2_WIDX $job $COMOUT/${ifile_spr}.idx" >>poe_alert.${nfhrs} 
+
+      tfile=0
       for mem in $memberlist; do
         ifile_mem=cmc_ge${mem}.t${cyc}z.pgrb2a.0p50.f${nfhrs}
-        echo "$DBNROOT/bin/dbn_alert MODEL NAEFS_CMCENS_PGBA_GB2    $job $COMOUT/${ifile_mem}"     >>poe_alert.${nfhrs}
-        echo "$DBNROOT/bin/dbn_alert MODEL NAEFS_CMCENS_PGBA_GB2_WIDX    $job $COMOUT/${ifile_mem}.idx"     >>poe_alert.${nfhrs}
+        if [ -s $COMOUT/${ifile_mem} -a -s $COMOUT/${ifile_mem}.idx ]; then
+          echo "$DBNROOT/bin/dbn_alert MODEL NAEFS_CMCENS_PGBA_GB2    $job $COMOUT/${ifile_mem}"       >>poe_alert.${nfhrs}
+          echo "$DBNROOT/bin/dbn_alert MODEL NAEFS_CMCENS_PGBA_GB2_WIDX $job $COMOUT/${ifile_mem}.idx" >>poe_alert.${nfhrs}
+          (( tfile = tfile + 1 ))
+        else
+          echo "There is no file $COMOUT/${ifile_mem}"       >>poe_alert.${nfhrs}
+          echo "There is no file $COMOUT/${ifile_spr}.idx"   >>poe_alert.${nfhrs}
+        fi
       done
-    done
 
-  if [ -s poescript_alert ]; then
-    rm poescript_alert
-  fi
+      # Log the job running status to the log file  
+      if [ $tfile -eq $count ]; then
+        printf "naefs_cmcens_post" >> $DATA_RESTART/${logfile}
+      fi
 
-  for nfhrs in $hourlist; do
-    chmod +x poe_alert.${nfhrs}
-    echo ". ./poe_alert.${nfhrs}" >>poescript_alert
-  done
+      fi    # avg and spr are available
 
-  chmod +x poescript_alert
-  $APRUN poescript_alert
+      chmod +x poe_alert.${nfhrs}
+      echo ". ./poe_alert.${nfhrs}" >>poescript_alert
+    fi    ## check restart
 
-  fi
+    done  ###  $hourlist
+
+    chmod +x poescript_alert
+    $APRUN poescript_alert
+
+  fi    ### SENDDBN_GB2
+
 ## move up earlier to release the gempak job sooner - 05/14/2018 - JY
 #####################################################################
 ##  move event flag here, so gempak job will get cmc_geavg grib data

--- a/scripts/exnaefs_gefs_debias.sh
+++ b/scripts/exnaefs_gefs_debias.sh
@@ -8,6 +8,7 @@
 #         Aug   2007 - Add hybrid method to combine bias-corrected GFS and bias-corrected GEFS
 #         June  2015 - Add new variable (TCDC) 
 #         June  2016 - Modified for half degree ensembl forecasts
+#         Feb   2025 - Add restart capability
 # AUTHOR: Bo Cui  (wx20cb)
 ###############################################################################################
 
@@ -86,6 +87,13 @@ for nens in $memberlist; do
 
   for nfhrs in $hourlist; do
 
+   # if there was a run before, a directory DATA_RESTART must exist with data in it
+   logfile=gefs_debias_${PDY}${cyc}.logf${nfhrs}_${nens}
+
+   if [ -s ${DATA_RESTART}/${logfile} ]; then
+      echo "Restarts found in ${DATA_RESTART} logfile=${logfile}"
+   else
+   
 ###
 #  set the index ( exist of bias estimation ) as default, 0
 ###
@@ -311,6 +319,10 @@ for nens in $memberlist; do
       fi
     done
 
+    # Log the job running status to the log file
+    printf "gefs_debias" >> $DATA_RESTART/$logfile                             
+              
+  fi
   done
 done
 

--- a/scripts/exnaefs_prob_avgspr.sh
+++ b/scripts/exnaefs_prob_avgspr.sh
@@ -5,6 +5,7 @@ echo "NAEFS products generation from combined NCEP/GEFS and CMC/EPS ensembles"
 echo "------------------------------------------------"
 echo "History: Oct 2013 - First implementation of this new script."
 echo "         Oct 2016 - Modified for half degree ensembles."
+echo "         Feb 2025 - Add restart capability"
 echo "AUTHOR: Bo Cui  (wx20cb)"
 
 ###############################################################################
@@ -58,6 +59,14 @@ grid2="0 6 0 0 0 0 0 0 360 181 0 0 90000000 0 48 -90000000 359000000 1000000 100
 if [ "$IFNAEFS" = "YES" ]; then
 
   for nfhrs in $hourlist; do
+
+    # if there was a run before, a directory DATA_RESTART must exist with data in it
+
+    logfile=naefs_prob_avgspr_${PDY}${cyc}.logf${nfhrs}
+
+    if [ -s ${DATA_RESTART}/${logfile} ]; then
+      echo "Restarts found in ${DATA_RESTART} logfile=${logfile}"
+    else
 
     export FHRLIST=$nfhrs
 
@@ -134,6 +143,10 @@ if [ "$IFNAEFS" = "YES" ]; then
 
     fi
 
+    # Log the job running status to the log file  
+    printf "naefs_prob_avgspr" >> $DATA_RESTART/${logfile}                                             
+
+    fi
   done
 fi
 
@@ -144,6 +157,11 @@ fi
 if [ "$IFGEFS" = "YES" ]; then
 
   for nfhrs in $hourlist; do
+
+    logfile=gefs_prob_avgspr_${PDY}${cyc}.logf${nfhrs}
+    if [ -s ${DATA_RESTART}/${logfile} ]; then
+      echo "Restarts found in ${DATA_RESTART} logfile=${logfile}"
+    else
 
     export FHRLIST=$nfhrs
 
@@ -224,6 +242,10 @@ if [ "$IFGEFS" = "YES" ]; then
               # $DBNROOT/bin/dbn_alert MODEL NAEFS_GEFS_AN_GB2_WIDX $job $COMOUTGEFSAN_p5/$oefi_gefs_gb2.idx
     fi
 
+    # Log the job running status to the log file  
+    printf "naefs_gefs_prob_avgspr" >> $DATA_RESTART/${logfile}
+
+    fi
   done
 fi
 

--- a/scripts/exnawips_cmce.sh
+++ b/scripts/exnawips_cmce.sh
@@ -74,6 +74,13 @@ while [ $fhcnt -le $fend ] ; do
   fhr3=$fhcnt
   typeset -Z3 fhr3
 
+# if there was a run before, a directory DATA_RESTART must exist with data in it
+  logfile=nawips_cmce_${PDY}${cyc}.logf${fhr3}_${member}
+  
+  if [ -s ${DATA_RESTART}/${logfile} ]; then
+    echo "Restarts found in ${DATA_RESTART} logfile=${logfile}"
+  else
+
   GRIBIN=$COMIN/cmc_ge${member}.${cycle}.pgrb2a.0p50.f${fhr3}
   if [ -s $GRIBIN ]
   then
@@ -111,10 +118,12 @@ EOF
 
   if [ $SENDCOM = "YES" ] ; then
      cp $GEMGRD $COMOUT/.$GEMGRD
-      cpfs $COMOUT/.$GEMGRD $COMOUT/$GEMGRD
+     cpfs $COMOUT/.$GEMGRD $COMOUT/$GEMGRD
      if [ $SENDDBN = "YES" ] ; then
          $DBNROOT/bin/dbn_alert MODEL ${DBN_ALERT_TYPE} $job \
            $COMOUT/$GEMGRD
+         # Log the job running status to the log file
+         printf "nawips_cmce" >> $DATA_RESTART/${logfile}
      else
        echo "##### DBN_ALERT_TYPE is: ${DBN_ALERT_TYPE} #####"
      fi
@@ -124,6 +133,8 @@ else
   echo "WARNING:$GRIB2IN is missing!!!"
 fi
 
+  fi   ## check restart
+  
   if [ $fhcnt -lt 192 ] ; then
     finc=03
   else

--- a/scripts/exnawips_fnmoc.sh
+++ b/scripts/exnawips_fnmoc.sh
@@ -5,6 +5,7 @@ echo "exnawips - convert FNMOC GRIB files into GEMPAK Grids"
 echo "----------------------------------------------------"
 echo "History: Jan 2011 - First implementation of this new script."
 echo "         Aug 2022 - Modified for 0.5d ensmeble forecast"
+echo "         Feb 2025 - Add restart capability"
 #####################################################################
 
 
@@ -56,6 +57,13 @@ while [ $fhcnt -le $fend ] ; do
 
   fhr3=$fhcnt
   typeset -Z3 fhr3
+
+  # if there was a run before, a directory DATA_RESTART must exist with data in it
+  logfile=nawips_fnmoc_${PDY}${cyc}.logf${fhr3}_0${member}
+ 
+  if [ -s ${DATA_RESTART}/${logfile} ]; then
+    echo "Restarts found in ${DATA_RESTART}, logfile=${logfile}"
+  else
 
   GRIB2IN=$COMIN/ENSEMBLE.halfDegree.MET.fcst_${model}0${member}.${fhr3}.${PDY}${cyc}
   GRIBIN=${SUBRUN}.${cycle}.0p50.pgrbaf${fhr}
@@ -179,18 +187,26 @@ fi    # if fhr=00
    if [ $SENDDBN = "YES" ] ; then
        $DBNROOT/bin/dbn_alert MODEL ${DBN_ALERT_TYPE} $job \
          $COMOUT/$GEMGRD
+       # Log the job running status to the log file  
+       printf "nawips_fnmoc" >> $DATA_RESTART/${logfile}
    fi
  fi
+
 
 elif [ ! -s $GRIB2IN ]; then
   echo "WARNING:$GRIB2IN is missing!!!"
 fi
+
+  # end of restart check
+  fi
+
   if [ $fhcnt -lt 192 ] ; then
     finc=03
   else
     finc=06
   fi
  let fhcnt=fhcnt+finc
+
 done
 
 #####################################################################

--- a/scripts/exnawips_naefs.sh
+++ b/scripts/exnawips_naefs.sh
@@ -173,7 +173,18 @@ while [ $fhcnt -le $fend ] ; do
                  GEMGRD=${model}${member}_${PDY}${cyc}f${fhr3}
                fi ;;
   esac
-  
+
+  # if there was a run before, a directory DATA_RESTART must exist with data in it
+  logfile=nawips_${SUBRUN}_${model}_${PDY}${cyc}.logf${fhr3}
+  if [ $# = 9 ]; then
+    logfile=nawips_${SUBRUN}_${model}_${PDY}${cyc}.logf${fhr3}_$9
+  fi
+ 
+  if [ -s ${DATA_RESTART}/${logfile} ]; then
+    echo "Restarts found in ${DATA_RESTART} logfile=${logfile}"
+  else
+
+  # start to generate product if there is no rerun
   icnt=1
   skip=0
   while [ $icnt -lt 1000 ]
@@ -228,11 +239,13 @@ EOF
 
     if [ $SENDCOM = "YES" ] ; then
        cp $GEMGRD $COMOUT/.$GEMGRD
-        cpfs $COMOUT/.$GEMGRD $COMOUT/$GEMGRD
+       cpfs $COMOUT/.$GEMGRD $COMOUT/$GEMGRD
        # if [ $SENDDBN = "YES" ] ; then
        if [ $SENDDBN = "YES" -a $model != "geavgan" -a $model != "geefi" ] ; then
            $DBNROOT/bin/dbn_alert MODEL ${DBN_ALERT_TYPE} $job \
            $COMOUT/$GEMGRD
+           # Log the job running status to the log file  
+           printf "nawips_naefs" >> $DATA_RESTART/${logfile}
        else
          echo "##### DBN_ALERT_TYPE is: ${DBN_ALERT_TYPE} #####"
          echo "Data NOT alert: SENDDBN=$SENDDBN, model=$model"
@@ -241,13 +254,15 @@ EOF
 
   fi      # skip
 
+  fi      # check restart
+
   if [ $fhcnt -lt 192 ] ; then
     finc=03
   else
     finc=06
   fi
-  let fhcnt=fhcnt+finc
 
+  let fhcnt=fhcnt+finc
 done
 
 #####################################################################


### PR DESCRIPTION
 # Description
<!-- This description will become the commit message for the PR-->
This PR will add restart capability to the below jobs. These jobs will create a restart directory under ptmp ($DATAROOT). Some log files and midterm products are saved and used once a re-run starts. 

1. CMC and FNMOC ensemble post-process jobs/scripts

jobs/JNAEFS_CMC_ENS_GEMPAK
jobs/JNAEFS_CMC_ENS_POST
jobs/JNAEFS_FNMOC_ENS_GEMPAK

scripts/exnaefs_cmcens_post.sh
scripts/exnawips_cmce.sh
scripts/exnawips_fnmoc.sh

2. GEFS ensemble post-process jobs/scripts

jobs/JNAEFS_GEFS_BIAS_GEMPAK
jobs/JNAEFS_GEFS_DEBIAS
jobs/JNAEFS_GEFS_DEBIAS_GEMPAK
jobs/JNAEFS_GEFS_PROB_AVGSPR_GEMPAK
jobs/JNAEFS_GEFS_PROB_AVGSPR

scripts/exnawips_naefs.sh
scripts/exnaefs_gefs_debias.sh

3.  NAEFS post-process jobs/scripts
 
jobs/JNAEFS_PROB_AVGSPR_GEMPAK
jobs/JNAEFS_PROB_AVGSPR
scripts/exnaefs_prob_avgspr.sh
 
Resolving #26 

 # Type of change
<!-- Delete all except one -->
- New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
  - Cycled test on WCOSS2
 
# Checklist
- [ ] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary