### PR TITLE
Add restart capability to downscaled jobs/scripts

### DIFF
--- a/jobs/JNAEFS_DVRTMA_BIAS_ALASKA_GEMPAK
+++ b/jobs/JNAEFS_DVRTMA_BIAS_ALASKA_GEMPAK
@@ -84,6 +84,9 @@ setpdy.sh
 export COMIN=${COMIN:-$(compath.py $envir/$NET/${naefs_ver})/${RUN}.${PDY}/${cyc}/ndgd_gb2}
 export COMOUT=${COMOUT:-$(compath.py -o $NET/${naefs_ver})/${RUN}.${PDY}/gempak}
 
+# Create a restart directory in ptmp to hold temporary output
+export DATA_RESTART=${DATAROOT}/$NET/${naefs_ver}/${RUN}.${PDY}/${cyc}/restart
+if [[ ! -d ${DATA_RESTART} ]]; then mkdir -p "${DATA_RESTART}"; fi
 
 if [ ! -f $COMOUT ] ; then
   mkdir -p -m 775 $COMOUT
@@ -106,5 +109,7 @@ postmsg "$jlogfile" "$msg"
 cd $DATAROOT
 
 if [ $KEEPDATA = NO ]; then rm -rf $DATA; fi
+
+#rm -rf $DATA_RESTART
 
 date

--- a/jobs/JNAEFS_DVRTMA_BIAS_CONUS_GEMPAK
+++ b/jobs/JNAEFS_DVRTMA_BIAS_CONUS_GEMPAK
@@ -77,6 +77,10 @@ setpdy.sh
 export COMIN=${COMIN:-$(compath.py $envir/$NET/${naefs_ver})/${RUN}.${PDY}/${cyc}/ndgd_gb2}
 export COMOUT=${COMOUT:-$(compath.py -o $NET/${naefs_ver})/${RUN}.${PDY}/gempak}
 
+# Create a restart directory in ptmp to hold temporary output
+export DATA_RESTART=${DATAROOT}/$NET/${naefs_ver}/${RUN}.${PDY}/${cyc}/restart
+if [[ ! -d ${DATA_RESTART} ]]; then mkdir -p "${DATA_RESTART}"; fi
+
 if [ ! -f $COMOUT ] ; then
   mkdir -p -m 775 $COMOUT
 fi
@@ -90,5 +94,7 @@ ${HOMEnaefs}/scripts/exnawips_naefs.sh $DATA 00 00 $COMIN $COMOUT naefs dvrtma N
 
 cd $DATAROOT
 if [ $KEEPDATA = NO ]; then rm -rf $DATA; fi
+
+#rm -rf $DATA_RESTART
 
 date

--- a/jobs/JNAEFS_DVRTMA_PROB_AVGSPR_ALASKA_GEMPAK
+++ b/jobs/JNAEFS_DVRTMA_PROB_AVGSPR_ALASKA_GEMPAK
@@ -82,6 +82,10 @@ setpdy.sh
 export COMIN=${COMIN:-$(compath.py $envir/$NET/${naefs_ver})/${RUN}.${PDY}/${cyc}/ndgd_gb2}
 export COMOUT=${COMOUT:-$(compath.py -o $NET/${naefs_ver})/${RUN}.${PDY}/gempak}
 
+# Create a restart directory in ptmp to hold temporary output
+export DATA_RESTART=${DATAROOT}/$NET/${naefs_ver}/${RUN}.${PDY}/${cyc}/restart
+if [[ ! -d ${DATA_RESTART} ]]; then mkdir -p "${DATA_RESTART}"; fi
+
 if [ ! -f $COMOUT ] ; then
   mkdir -p -m 775 $COMOUT
 fi
@@ -134,5 +138,6 @@ cat $DATA/dir_384/output_geavg_384
 cd $DATAROOT
 
 if [ $KEEPDATA = NO ]; then rm -rf $DATA; fi
+#rm -rf $DATA_RESTART
 
 date

--- a/jobs/JNAEFS_DVRTMA_PROB_AVGSPR_CONUS_GEMPAK
+++ b/jobs/JNAEFS_DVRTMA_PROB_AVGSPR_CONUS_GEMPAK
@@ -82,6 +82,10 @@ setpdy.sh
 export COMIN=${COMIN:-$(compath.py $envir/$NET/${naefs_ver})/${RUN}.${PDY}/${cyc}/ndgd_gb2}
 export COMOUT=${COMOUT:-$(compath.py -o $NET/${naefs_ver})/${RUN}.${PDY}/gempak}
 
+# Create a restart directory in ptmp to hold temporary output
+export DATA_RESTART=${DATAROOT}/$NET/${naefs_ver}/${RUN}.${PDY}/${cyc}/restart
+if [[ ! -d ${DATA_RESTART} ]]; then mkdir -p "${DATA_RESTART}"; fi
+
 if [ ! -f $COMOUT ] ; then
   mkdir -p -m 775 $COMOUT
 fi
@@ -135,5 +139,6 @@ cat $DATA/dir_384/output_geavg_384
 cd $DATAROOT
 
 if [ $KEEPDATA = NO ]; then rm -rf $DATA; fi
+#rm -rf $DATA_RESTART
 
 date


### PR DESCRIPTION
 # Description
<!-- This description will become the commit message for the PR-->
This PR will add restart capability to the below jobs. These jobs will create a restart directory under ptmp ($DATAROOT). Some log files and midterm products are saved and used once a re-run starts. 

jobs/JNAEFS_DVRTMA_BIAS_ALASKA_GEMPAK
jobs/JNAEFS_DVRTMA_BIAS_CONUS_GEMPAK

 jobs/JNAEFS_DVRTMA_PROB_AVGSPR_ALASKA_GEMPAK
jobs/JNAEFS_DVRTMA_PROB_AVGSPR_CONUS_GEMPAK 
 
 
Resolved #26 

 # Type of change
<!-- Delete all except one -->
- New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
  - Cycled test on WCOSS2
 
# Checklist
- [ ] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary