### PR TITLE
Fix Bug 742 -  improve fnmoc jobs to send out notification 

### DIFF
--- a/jobs/JNAEFS_FNMOC_ENS_BIAS
+++ b/jobs/JNAEFS_FNMOC_ENS_BIAS
@@ -96,6 +96,11 @@ export ERRSCRIPT=err_chk
 export REDOUT='1>>'
 export REDERR='2>'
 
+####################################
+# Mail List
+####################################
+export MAILTO=${MAILTO:-'nco.spa@noaa.gov,ncep.sos@noaa.gov,nco.sos@noaa.gov'}
+
 #########################################
 # Run setpdy and initialize PDY variables
 #########################################
@@ -132,6 +137,7 @@ env
 ####################
 
 $HOMEfnmoc/scripts/exnaefs_fnmoc_ens_bias.sh
+export err=$?; err_chk
 
 cat $pgmout.000.anl
 cat $pgmout.000.mdf

--- a/jobs/JNAEFS_FNMOC_ENS_DEBIAS
+++ b/jobs/JNAEFS_FNMOC_ENS_DEBIAS
@@ -166,11 +166,13 @@ export DATA=$DATAHOLD/dir_avgspr_bc
 mkdir -p $DATA
 cd $DATA
 $USHfnmoc/fnmocens_bc_avgspr.sh
+export err=$?; err_chk
 
 export DATA=$DATAHOLD/dir_avgspr
 mkdir -p $DATA
 cd $DATA
 $USHfnmoc/fnmocens_avgspr.sh                  
+export err=$?; err_chk
 
 cat $DATAHOLD/group.006/$pgmout.006.p02_an
 cat $DATAHOLD/group.006/$pgmout.006.p02_wt 

--- a/jobs/JNAEFS_FNMOC_ENS_GEMPAK
+++ b/jobs/JNAEFS_FNMOC_ENS_GEMPAK
@@ -85,7 +85,14 @@ export EXECnaefs=${EXECnaefs:-$HOMEnaefs/exec}
 export FIXnaefs=${FIXnaefs:-$HOMEnaefs/fix}
 export USHnaefs=${USHnaefs:-$HOMEnaefs/ush}
 
+####################################
+# Mail List
+####################################
+export MAILTO=${MAILTO:-'nco.spa@noaa.gov,ncep.sos@noaa.gov,nco.sos@noaa.gov'}
+
+#########################################
 # Run setpdy and initialize PDY variables
+#########################################
 setpdy.sh
 . ./PDY
 
@@ -126,6 +133,22 @@ chmod 775 $DATA/poescript
 # Execute the script.
 $APRUN $DATA/poescript
 export err=$?; err_chk
+
+cd $DATA
+for ftype in et; do
+  for member in 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20; do 
+    if [ -s "$DATA/${member}_$ftype/missing_fens.txt" ]; then
+      sort -u $DATA/${member}_$ftype/missing_fens.txt    >> $DATA/missing_files
+    fi
+  done
+done
+if [ -s "$DATA/missing_files" ]; then
+  echo "One or more FNMOC files are missing, including:"  > $DATA/mail_message
+  cat $DATA/missing_files                                >> $DATA/mail_message
+  echo ""                                                >> $DATA/mail_message 
+  echo "$0 could not process all expected data."         >> $DATA/mail_message 
+  cat $DATA/mail_message | mail.py -s "Missing FNMOC data in $job" ${MAILTO:?} -v
+fi
 
 cat $DATA/01_et/output
 cat $DATA/11_et/output

--- a/scripts/exnaefs_fnmoc_ens_bias.sh
+++ b/scripts/exnaefs_fnmoc_ens_bias.sh
@@ -244,8 +244,10 @@ for nfhrs in 000; do
   afile=$COMINnavgem/US058GMET-OPSbd2.NAVGEM000-${aymd}${acyc}-NOAA-halfdeg.gr2
 
   if [ ! -s $afile ]; then
-    echo " FATAL ERROR: There is no FNMOC Analysis data, Stop! for " ${aymd}${acyc}
-    export err=1; err_chk
+    echo "$afile" >> ${DATA}/missing_fens.txt
+    cat $DATA/missing_fens.txt | mail.py -s "Missing FNMOC data in $job" ${MAILTO:?} -v
+    echo " FATAL ERROR: There is no FNMOC Analysis data, Stop!" $afile            
+    exit                     
   fi
 
 ###
@@ -260,15 +262,18 @@ for nfhrs in 000; do
   grid2="0 6 0 0 0 0 0 0 720 361 0 0 90000000 0 48 -90000000 359500000 500000 500000 0"
 
   if [ ! -s $rfile_in ]; then
-    echo "FATAL ERROR: There is no CFS Reanalysis data, Stop! for " ${aymd}${acyc}
-    export err=1; err_chk
+    echo "FATAL ERROR: There is no CFS Reanalysis data, Stop!" $rfile_in      
+    export err=$?;err_chk
   fi
   if [ ! -s $rfile_m06in ]; then
-    echo " There is no CFS Reanalysis data, Stop! for " ${aymd_m06}${acyc_m06}
+    echo "FATAL ERROR: There is no CFS Reanalysis data, Stop! " $rfile_m06in             
+    export err=$?;err_chk
   fi
 
-  $COPYGB2 -g "$grid2" -x $rfile_in    $rfile
-  $COPYGB2 -g "$grid2" -x $rfile_m06in $rfile_m06
+  if [ -s $rfile_in -a -s $rfile_m06in ]; then
+    $COPYGB2 -g "$grid2" -x $rfile_in    $rfile
+    $COPYGB2 -g "$grid2" -x $rfile_m06in $rfile_m06
+  fi
 
 ###
 #  get initialized bias between analyais and reanalysis entry
@@ -352,7 +357,7 @@ for nfhrs in 000; do
   nfile=$COMINgefs/gefs.${aymd}/${acyc}/atmos/pgrb2ap5/gec00.t${acyc}z.pgrb2a.0p50.f000
 
   if [ ! -s $nfile ]; then
-    echo " FATAL ERROR:There is no GEFS Analysis data, Stop! for " ${aymd}${acyc}
+    echo " FATAL ERROR:There is no GEFS Analysis data, Stop! " ${nfile}       
     export err=1; err_chk
   fi
 
@@ -363,10 +368,11 @@ for nfhrs in 000; do
   cfile=$COMINnavgem/US058GMET-OPSbd2.NAVGEM000-${aymd}${acyc}-NOAA-halfdeg.gr2
 
   if [ ! -s $cfile ]; then
-    echo "FATAL ERROR: There is no FNMOC Analysis data, Stop! for " ${aymd}${acyc}
-    export err=1; err_chk
+    echo "$cfile" >> ${DATA}/missing_fens.txt
+    cat $DATA/missing_fens.txt | mail.py -s "Missing FNMOC data in $job" ${MAILTO:?} -v
+    echo " FATAL ERROR: There is no FNMOC Analysis data, Stop!" $cfile            
+    exit                    
   fi
-
 ###
 #  get initialized bias between NCEP and FNMOC analysis 
 ###

--- a/scripts/exnaefs_fnmoc_ens_debias.sh
+++ b/scripts/exnaefs_fnmoc_ens_debias.sh
@@ -83,8 +83,10 @@ do
         ln -sf $ifile_in $ofile
         export MEMLIST=$nens
         $ENSANOMALY $PDY$cyc $nfhrs
+        export err=1; err_chk
 
         $ENSWEIGHTS $PDY$cyc $nfhrs
+        export err=1; err_chk
 
         icnt=31
 

--- a/scripts/exnawips_fnmoc.sh
+++ b/scripts/exnawips_fnmoc.sh
@@ -195,6 +195,7 @@ fi    # if fhr=00
 
 elif [ ! -s $GRIB2IN ]; then
   echo "WARNING:$GRIB2IN is missing!!!"
+  echo "$GRIB2IN" >> ${DATA}/missing_fens.txt
 fi
 
   # end of restart check

--- a/ush/fnmocens_climate_anomaly.sh
+++ b/ush/fnmocens_climate_anomaly.sh
@@ -93,7 +93,8 @@ do
  echo "/" >>input_$ens
 
  $EXECfnmoc/$pgm  <input_$ens >$pgmout.$FHR.${ens}_an 2> errfile
- export err=$?
+ export err=$?;err_chk
+
  if [ $err -eq 0 ]; then
    mv anom_$ens.dat fnmoc_ge${ens}.t${cyc}z.pgrb2a.0p50_anf${FHR}
  else


### PR DESCRIPTION
# Description
<!-- This description will become the commit message for the PR-->
This PR is to improve fnmoc jobs. The three fnmoc jobs are treated as data of opportunity. If there is missing/delay fnmoc dcom data or there is corrupt dcom data,  the improved fnmoc jobs will not fail but  send out an notification email to SPAhelpdesk, SOSer and SDM with a warning message for the problem.  
 
jobs/
JNAEFS_FNMOC_ENS_BIAS 
JNAEFS_FNMOC_ENS_DEBIAS 
JNAEFS_FNMOC_ENS_GEMPAK 

scripts/
exnaefs_fnmoc_ens_bias.sh 
exnaefs_fnmoc_ens_debias.sh
exnawips_fnmoc.sh 
 
ush/
fnmocens_climate_anomaly.sh 
 
Resolved #34 
# Type of change
<!-- Delete all except one -->
 - [x] Bug fix (fixes something broken)
 
# Change characteristics
- Is this a breaking change (a change in existing functionality)?  NO
- Does this change require a documentation update?  NO

# How has this been tested?
 - Cycled test on WCOSS2
 
# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary