### PR TITLE
Fix Bug 1531 - Improve naefs_gefs_pgrb_enspqpf job's error handle for no GEFS input data

### DIFF
--- a/scripts/exnaefs_gefs_pgrb_enspqpf.sh
+++ b/scripts/exnaefs_gefs_pgrb_enspqpf.sh
@@ -47,6 +47,7 @@ fi
 for nfhrs in $hourlist; do
   for nens in $memberlist; do
     infile=$COMINgefs/ge${nens}.t${cyc}z.pgrb2a.0p50.f${nfhrs}                  
+    if [ -s $infile ]; then
     $WGRIB2 -match ":APCP:" $infile  -append -grib  $outfile_prcp
     if [ "$HRINTER" = "6" ]; then
       $WGRIB2 -match ":CRAIN:" $infile  -append -grib  $outfile_rain
@@ -54,8 +55,16 @@ for nfhrs in $hourlist; do
       $WGRIB2 -match ":CICEP:" $infile  -append -grib  $outfile_icep
       $WGRIB2 -match ":CSNOW:" $infile  -append -grib  $outfile_snow
     fi
+    else
+      echo "Warning: missing input file $infile"
+    fi
   done
 done
+
+if [ ! -s $outfile_prcp ]; then
+  echo "FATAL ERROR: missing all input files in " $COMINgefs
+  export err=1; err_chk
+fi
 
 # Specify the input/output file names:
 


### PR DESCRIPTION
 # Description
<!-- This description will become the commit message for the PR-->
This PR fixes bugzilla ticket  1531 to Improve naefs_gefs_pgrb_enspqpf job's error handle for no GEFS input data

scripts/exnaefs_gefs_pgrb_enspqpf.sh

Resolved #42 

# Type of change
<!-- Delete all except one -->
 - [x] Bug fix (fixes something broken)
 - [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)
 
# Change characteristics
- Is this a breaking change (a change in existing functionality)?  NO
- Does this change require a documentation update?  NO

# How has this been tested?
 - Cycled test on WCOSS2
 
# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary