### PR TITLE
Fix Bug 1532 - improve naefs_cmc_ens_gempak job error handling

### DIFF
--- a/jobs/JNAEFS_CMC_ENS_GEMPAK
+++ b/jobs/JNAEFS_CMC_ENS_GEMPAK
@@ -33,8 +33,11 @@ export cycle=t${cyc}z
 
 export jlogfile=${jlogfile:-${DATA}/jlogfile.${job}.${pid}}
 
-####################################
-#
+###########
+# Mail List
+###########
+export MAILTO=${MAILTO:-'nco.spa@noaa.gov,ncep.sos@noaa.gov,nco.sos@noaa.gov'}
+
 ####################################
 export SENDCOM=${SENDCOM:-YES}
 export SENDECF=${SENDECF:-YES}
@@ -121,11 +124,34 @@ chmod 775 $DATA/poescript_gempak
 $APRUN poescript_gempak
 export err=$?; err_chk
 
+# nfile: number of available input files
+
+nfile=0
+for nfhrs in $hourlist; do
+  if [ -s ${DATA}/dir_${nfhrs}/missing_cmce.txt ]; then
+    cat ${DATA}/dir_${nfhrs}/missing_cmce.txt   >> ${DATA}/total_missing_cmce.txt
+  else
+    (( nfile = nfile + 1 ))
+  fi
+done 
+
+if [ -s "$DATA/total_missing_cmce.txt" ]; then
+  echo ""                                               >> $DATA/mail_message
+  echo "One or more CMC files are missing,including:"   >> $DATA/mail_message
+  cat $DATA/total_missing_cmce.txt                      >> $DATA/mail_message
+  if [ $nfile -eq 0 ]; then
+    echo ""                                               >> $DATA/mail_message
+    echo "FATAL ERROR: missing all input files in $COMIN" >> ${DATA}/mail_message     
+    cat $DATA/mail_message | mail.py -s "Missing CMC data in $job" ${MAILTO:?} -v
+    echo "FATAL ERROR: missing all input files in " $COMIN
+    export err=1; err_chk
+  fi
+fi
+
 cat $DATA/dir_024/output_p01_024
 cat $DATA/dir_360/output_p01_360
 cat $DATA/dir_024/output_avg_024
 cat $DATA/dir_360/output_avg_360
-
 ########################################################
 
 cd $DATAROOT

--- a/scripts/exnawips_cmce.sh
+++ b/scripts/exnawips_cmce.sh
@@ -130,7 +130,8 @@ EOF
   fi
 
 else 
-  echo "WARNING:$GRIB2IN is missing!!!"
+  echo "WARNING:$GRIBIN is missing!!!"
+  echo "WARNING:$GRIBIN is missing!!!" >> ${DATA}/missing_cmce.txt
 fi
 
   fi   ## check restart


### PR DESCRIPTION
 # Description
<!-- This description will become the commit message for the PR-->
This PR fixes bugzilla ticket  1532 to improve the naefs_cmc_ens_gempak job error handling for missing naefs cmce pgrb2ap5 input data.

jobs/JNAEFS_CMC_ENS_GEMPAK
scripts/exnawips_cmce.sh 

Resolved #43 

# Type of change
<!-- Delete all except one -->
 - [x] Bug fix (fixes something broken)
 - [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)
 
# Change characteristics
- Is this a breaking change (a change in existing functionality)?  NO
- Does this change require a documentation update?  NO

# How has this been tested?
 - Cycled test on WCOSS2
 
# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary